### PR TITLE
Fix #60

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-netCDF4==1.1.8
-numpy==1.9.2
+netCDF4
+numpy

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,21 @@
 from __future__ import with_statement
 
+import os
 from setuptools import setup, find_packages
 
-from pysgrid import __version__
+def extract_version(module='pysgrid'):
+    version = None
+    fdir = os.path.dirname(__file__)
+    fnme = os.path.join(fdir, module, '__init__.py')
+    with open(fnme) as fd:
+        for line in fd:
+            if (line.startswith('__version__')):
+                _, version = line.split('=')
+                # Remove quotation characters.
+                version = version.strip()[1:-1]
+                break
+    return version
+
 
 reqs = [line.strip() for line in open('requirements.txt')]
 
@@ -13,7 +26,7 @@ def readme():
 
 setup(
     name                = 'pysgrid',
-    version             = __version__,
+    version             = extract_version(),
     description         = 'Python package for working with staggered gridded data',
     author              = 'Andrew Yan',
     author_email        = 'ayan@usgs.gov',


### PR DESCRIPTION
This PR relaxes the pinned versions for `numpy` and `netCDF4-python`.  Let's see if I can break a few tests!