### PR TITLE
import Dataset

### DIFF
--- a/pysgrid/custom_exceptions.py
+++ b/pysgrid/custom_exceptions.py
@@ -9,17 +9,17 @@ import warnings
 
 
 class CannotFindPaddingError(Exception):
-    
+
     base_message = 'The netCDF file appears to have conform to SGRID conventions, but padding values cannot be found.'
-        
+
     def __str__(self):
         return self.base_message
 
 
 class SGridNonCompliantError(Exception):
-    
+
     base_message = 'This netCDF object derived from the dataset at {0} does not appear to be SGRID compliant.'
-    
+
     def __init__(self, dataset_path):
         self.dataset_path = dataset_path
 
@@ -27,8 +27,8 @@ class SGridNonCompliantError(Exception):
         error_message = self.base_message.format(self.dataset_path)
         return error_message
 
-    
-    
+
+
 def deprecated(deprecated_function):
     @functools.wraps(deprecated_function)
     def new_func(*args, **kwargs):
@@ -39,4 +39,3 @@ def deprecated(deprecated_function):
                                )
         return deprecated_function(*args, **kwargs)
     return new_func
-        

--- a/pysgrid/lookup.py
+++ b/pysgrid/lookup.py
@@ -7,7 +7,7 @@ Created on Mar 24, 2015
 
 LAT_GRID_CELL_CENTER_LONG_NAME = ['latitude of RHO-points',  # ROMS
                                   'X-coordinate of grid points',  # deltares
-                                  ] 
+                                  ]
 
 LON_GRID_CELL_CENTER_LONG_NAME = ['longitude of RHO-points',  # ROMS
                                   'Y-coordinate of grid points',  # deltares
@@ -18,7 +18,7 @@ LAT_GRID_CELL_NODE_LONG_NAME = ['latitude of PSI-points',  # ROMS
                                 ]
 
 LON_GRID_CELL_NODE_LONG_NAME = ['longitude of PSI-points',  # ROMS
-                                'grid cell corners, longitude-coordinate',  # deltares 
+                                'grid cell corners, longitude-coordinate',  # deltares
                                 ]
 
 

--- a/pysgrid/processing_2d.py
+++ b/pysgrid/processing_2d.py
@@ -10,14 +10,14 @@ def vector_sum(x_arr, y_arr):
     """
     Calculate the vector sum of arrays of
     x and y vectors.
-    
+
     :param x_arr: array of x-directed vectors
     :type x_arr: numpy.array
     :param y_arr: array of y-directed vectors
     :type y_arr: numpy.array
     :return: array of vector sums
     :rtype: numpy.array
-    
+
     """
     vector_sum = np.sqrt(x_arr**2 + y_arr**2)
     return vector_sum
@@ -28,9 +28,9 @@ def rotate_vectors(x_arr, y_arr, angle_arr):
     Given x and y vectors in a projected coordinate
     system, rotate them by angles into a different
     coordinate system.
-    
+
     All arrays must have the same dimensions.
-    
+
     :param x_arr: array of x-directed vectors
     :type x_arr: numpy.array
     :param y_arr: array of y-directed vectors
@@ -39,7 +39,7 @@ def rotate_vectors(x_arr, y_arr, angle_arr):
     :type angle_arr: numpy.array
     :return: x and y arrays of rotated vectors
     :rtype: tuple
-    
+
     """
     x_rot = x_arr*np.cos(angle_arr) - y_arr*np.sin(angle_arr)
     y_rot = x_arr*np.sin(angle_arr) + y_arr*np.cos(angle_arr)
@@ -52,13 +52,13 @@ def avg_to_cell_center(data_array, avg_dim):
     adjacent row values (avg_dim=1) or adjacent
     column values (avg_dim=0) to the grid cell
     center.
-    
+
     :param data_array: 2-dimensional data
     :type data_array: numpy.array
     :param int avg_dim: integer specify array axis to be averaged
     :return: averages
     :rtype: numpy.array
-    
+
     """
     if avg_dim == 0:
         da = np.transpose(data_array)

--- a/pysgrid/read_netcdf.py
+++ b/pysgrid/read_netcdf.py
@@ -14,20 +14,20 @@ def parse_padding(padding_str, mesh_topology_var):
     """
     Use regex expressions to break apart an
     attribute string containing padding types
-    for each variable with a cf_role of 
+    for each variable with a cf_role of
     'grid_topology'.
-    
+
     Padding information is returned within a named tuple
     for each node dimension of an edge, face, or vertical
     dimension. The named tuples have the following attributes:
     mesh_topology_var, dim_name, dim_var, and padding.
     Padding information is returned as a list
     of these named tuples.
-    
+
     :param str padding_str: string containing padding types from a netCDF attribute
     :return: named tuples with padding information
     :rtype: list
-    
+
     """
     p = re.compile('([a-zA-Z0-9_]+:) ([a-zA-Z0-9_]+) (\(padding: [a-zA-Z]+\))')
     padding_matches = p.findall(padding_str)
@@ -84,7 +84,7 @@ def parse_vector_axis(variable_standard_name):
 
 
 class NetCDFDataset(object):
-    
+
     def __init__(self, nc_dataset_obj):
         self.ncd = nc_dataset_obj
         # in case a user as a version netcdf C library < 4.1.2
@@ -93,14 +93,14 @@ class NetCDFDataset(object):
         except ValueError:
             self._filepath = None
         self.sgrid_compliant_file()
-        
+
     def find_node_coordinates(self, node_dimensions):
         """
         Find the variables for the grid
         cell vertices.
-        
+
         """
-        nc_vars = self.ncd.variables    
+        nc_vars = self.ncd.variables
         node_dims = node_dimensions.split(' ')
         node_dim_set = set(node_dims)
         x_node_coordinate = None
@@ -128,7 +128,7 @@ class NetCDFDataset(object):
             return x_node_coordinate, y_node_coordinate
         else:
             return None
-        
+
     def find_variables_by_attr(self, **kwargs):
         nc_vars = self.ncd.variables
         matches = []
@@ -146,17 +146,17 @@ class NetCDFDataset(object):
                 if attr_tracking == kwargs:
                     matches.append(nc_var)
         return matches
-                
+
     def find_grid_topology_var(self):
         """
         Get the variables from a netCDF dataset
         that have a cf_role attribute of 'grid_topology'.
-        
+
         :params nc: netCDF dataset
         :type nc: netCDF4.Dataset
         :return: list of variables that contain grid topologies
         :rtype: list
-        
+
         """
         nc_vars = self.ncd.variables
         grid_topology_var = None
@@ -174,18 +174,18 @@ class NetCDFDataset(object):
                     # exit the loop once the topology variable is found
                     break
         return grid_topology_var
-    
+
     def find_coordinates_by_location(self, location_str, topology_dim):
         """
         Find a grid coordinates variables with a location attribute equal
         to location_str. This method can be used to infer edge, face, or
         volume coordinates from the location attribute of a variable.
-        
+
         Location is a required attribute per SGRID conventions.
-        
+
         :param str location_str: the location value to search for
         :param int topology_dim: the topology dimension of the grid
-        
+
         """
         nc_vars = self.ncd.variables
         vars_with_location = self.find_variables_by_attr(location=location_str)
@@ -203,8 +203,8 @@ class NetCDFDataset(object):
                 for nc_var in nc_vars.keys():
                     nc_var_obj = nc_vars[nc_var]
                     nc_var_dim_set = set(nc_var_obj.dimensions)
-                    if (nc_var_dim_set.issubset(location_var_dims) and 
-                        nc_var != var_with_location and 
+                    if (nc_var_dim_set.issubset(location_var_dims) and
+                        nc_var != var_with_location and
                         len(nc_var_dim_set) > 0
                         ):
                         potential_coordinates.append(nc_var_obj)
@@ -235,16 +235,16 @@ class NetCDFDataset(object):
                     except AttributeError:
                         var_coord_desc = ''
                     if ('lon' in var_coord.name.lower() or
-                        'longitude' in var_coord_standard_name.lower() or 
+                        'longitude' in var_coord_standard_name.lower() or
                         'longitude' in var_coord_desc.lower()):
                         x_coordinate = lvc
-                    elif ('lat' in var_coord.name.lower() or 
+                    elif ('lat' in var_coord.name.lower() or
                           'latitude' in var_coord_standard_name.lower() or
                           'latitude' in var_coord_desc.lower()):
                         y_coordinate = lvc
                 if len(lvc_split) == 3:
                     z_coordinate = lvc_split[-1]
-                break 
+                break
         if topology_dim == 2:
             coordinates = (x_coordinate, y_coordinate)
         else:
@@ -259,10 +259,10 @@ class NetCDFDataset(object):
         """
         Determine whether a dataset is
         SGRID compliant.
-        
+
         :return: True if dataset is compliant, raise an exception if it is not
         :rtype: bool
-        
+
         """
         grid_vars = self.find_grid_topology_var()
         if grid_vars is not None:

--- a/pysgrid/tests/test_read_netcdf.py
+++ b/pysgrid/tests/test_read_netcdf.py
@@ -6,7 +6,7 @@ Created on Apr 7, 2015
 import os
 import unittest
 
-import netCDF4 as nc4
+from netCDF4 import Dataset
 
 from ..custom_exceptions import CannotFindPaddingError
 from ..read_netcdf import NetCDFDataset, parse_axes, parse_padding, parse_vector_axis
@@ -14,16 +14,16 @@ from .write_nc_test_files import roms_sgrid, wrf_sgrid_2d
 
 
 class TestParseAxes(unittest.TestCase):
-    
+
     def setUp(self):
         self.xy = 'X: xi_psi Y: eta_psi'
         self.xyz = 'X: NMAX Y: MMAXZ Z: KMAX'
-        
+
     def test_xyz_axis_parse(self):
         result = parse_axes(self.xyz)
         expected = ('NMAX', 'MMAXZ', 'KMAX')
         self.assertEqual(result, expected)
-        
+
     def test_xy_axis_parse(self):
         result = parse_axes(self.xy)
         expected = ('xi_psi', 'eta_psi', None)
@@ -31,19 +31,19 @@ class TestParseAxes(unittest.TestCase):
 
 
 class TestParsePadding(unittest.TestCase):
-    
+
     def setUp(self):
         self.grid_topology = 'some_grid'
         self.with_two_padding = 'xi_rho: xi_psi (padding: both) eta_rho: eta_psi (padding: low)'
         self.with_one_padding = 'xi_v: xi_psi (padding: high) eta_v: eta_psi'
         self.with_no_padding = 'MMAXZ: MMAX NMAXZ: NMAX'
-        
+
     def test_mesh_name(self):
         result = parse_padding(self.with_one_padding, self.grid_topology)
         mesh_topology = result[0].mesh_topology_var
         expected = 'some_grid'
         self.assertEqual(mesh_topology, expected)
-    
+
     def test_two_padding_types(self):
         result = parse_padding(self.with_two_padding, self.grid_topology)
         expected_len = 2
@@ -58,7 +58,7 @@ class TestParsePadding(unittest.TestCase):
         self.assertEqual(padding_type, expected_padding_type)
         self.assertEqual(sub_dim, expected_sub_dim)
         self.assertEqual(dim, expected_dim)
-        
+
     def test_one_padding_type(self):
         result = parse_padding(self.with_one_padding, self.grid_topology)
         expected_len = 1
@@ -73,114 +73,114 @@ class TestParsePadding(unittest.TestCase):
         self.assertEqual(padding_type, expected_padding_type)
         self.assertEqual(sub_dim, expected_sub_dim)
         self.assertEqual(dim, expected_dim)
-        
+
     def test_no_padding(self):
-        self.assertRaises(CannotFindPaddingError, 
-                          parse_padding, 
+        self.assertRaises(CannotFindPaddingError,
+                          parse_padding,
                           padding_str=self.with_no_padding,
                           mesh_topology_var=self.grid_topology
                           )
 
 
 class TestParseVectorAxis(unittest.TestCase):
-    
+
     def setUp(self):
         self.standard_name_1 = 'sea_water_y_velocity'
         self.standard_name_2 = 'atmosphere_optical_thickness_due_to_cloud'
         self.standard_name_3 = 'ocean_heat_x_transport_due_to_diffusion'
-        
+
     def test_std_name_with_velocity_direction(self):
         direction = parse_vector_axis(self.standard_name_1)
         expected_direction = 'Y'
         self.assertEqual(direction, expected_direction)
-        
+
     def test_std_name_without_direction(self):
         direction = parse_vector_axis(self.standard_name_2)
         self.assertIsNone(direction)
-        
+
     def test_std_name_with_transport_direction(self):
         direction = parse_vector_axis(self.standard_name_3)
         expected_direction = 'X'
         self.assertEqual(direction, expected_direction)
 
-        
+
 class TestNetCDFDatasetWithNodes(unittest.TestCase):
-    
+
     @classmethod
     def setUpClass(cls):
         cls.sgrid_test_file = roms_sgrid()
-        
+
     @classmethod
     def tearDownClass(cls):
         os.remove(cls.sgrid_test_file)
-    
+
     def setUp(self):
-        self.ds = nc4.Dataset(self.sgrid_test_file)
+        self.ds = Dataset(self.sgrid_test_file)
         self.nc_ds = NetCDFDataset(self.ds)
-        
+
     def tearDown(self):
         self.ds.close()
-        
+
     def test_finding_node_variables(self):
         result = self.nc_ds.find_node_coordinates('xi_psi eta_psi')
         expected = ('lon_psi', 'lat_psi')
         self.assertEqual(result, expected)
-        
+
     def test_find_face_coordinates_by_location(self):
         result = self.nc_ds.find_coordinates_by_location('face', 2)
         expected = ('lon_rho', 'lat_rho')
         self.assertEqual(result, expected)
-    
+
     def test_find_edge_coordinates_by_location(self):
         result = self.nc_ds.find_coordinates_by_location('edge1', 2)
         expected = ('lon_u', 'lat_u')
         self.assertEqual(result, expected)
-        
+
     def test_find_grid_topology(self):
         result = self.nc_ds.find_grid_topology_var()
         expected = 'grid'
         self.assertEqual(result, expected)
-        
+
     def test_find_variables_by_standard_name(self):
         result = self.nc_ds.find_variables_by_attr(standard_name='time')
         expected = ['time']
         self.assertEqual(result, expected)
-        
+
     def test_find_variables_by_standard_name_none(self):
         result = self.nc_ds.find_variables_by_attr(standard_name='some standard_name')
         self.assertEqual(result, [])
-        
+
     def test_sgrid_compliant_check(self):
         result = self.nc_ds.sgrid_compliant_file()
         self.assertTrue(result)
-        
-        
+
+
 class TestNetCDFDatasetWithoutNodes(unittest.TestCase):
-    
+
     @classmethod
     def setUpClass(cls):
         cls.sgrid_test_file = wrf_sgrid_2d()
-        
+
     @classmethod
     def tearDownClass(cls):
         os.remove(cls.sgrid_test_file)
-        
+
     def setUp(self):
-        self.ds = nc4.Dataset(self.sgrid_test_file)
+        self.ds = Dataset(self.sgrid_test_file)
         self.nc_ds = NetCDFDataset(self.ds)
-        
+
     def tearDown(self):
         self.ds.close()
-        
+
     def test_node_coordinates(self):
         node_coordinates = self.nc_ds.find_node_coordinates('west_east_stag south_north_stag')
         self.assertIsNone(node_coordinates)
-        
+
     def test_find_variable_by_attr(self):
         result = self.nc_ds.find_variables_by_attr(cf_role='grid_topology', topology_dimension=2)
         expected = ['grid']
         self.assertEqual(result, expected)
-        
+
     def test_find_variable_by_nonexistant_attr(self):
         result = self.nc_ds.find_variables_by_attr(bird='tufted titmouse')
         self.assertEqual(result, [])

--- a/pysgrid/tests/test_sgrid.py
+++ b/pysgrid/tests/test_sgrid.py
@@ -7,14 +7,14 @@ import os
 import unittest
 
 import mock
-import netCDF4 as nc4
+from netCDF4 import Dataset
 import numpy as np
 
 from ..custom_exceptions import SGridNonCompliantError
 from ..sgrid import SGrid2D, SGrid3D, from_ncfile, from_nc_dataset
 from ..utils import GridPadding
-from .write_nc_test_files import (deltares_sgrid, deltares_sgrid_no_optional_attr, 
-                                  non_compliant_sgrid, roms_sgrid, wrf_sgrid, 
+from .write_nc_test_files import (deltares_sgrid, deltares_sgrid_no_optional_attr,
+                                  non_compliant_sgrid, roms_sgrid, wrf_sgrid,
                                   wrf_sgrid_2d)
 
 
@@ -23,38 +23,38 @@ TEST_FILES = os.path.join(CURRENT_DIR, 'files')
 
 
 class TestSGridCompliant(unittest.TestCase):
-    
+
     @classmethod
     def setUpClass(cls):
         cls.sgrid_test_file = non_compliant_sgrid()
-        
+
     @classmethod
     def tearDownClass(cls):
         os.remove(cls.sgrid_test_file)
-        
+
     def test_exception_raised(self):
-        self.assertRaises(SGridNonCompliantError, 
+        self.assertRaises(SGridNonCompliantError,
                           from_ncfile,
                           self.sgrid_test_file
                           )
 
 
 class TestSGridCreate(unittest.TestCase):
-    
+
     @classmethod
     def setUpClass(cls):
         cls.sgrid_test_file = roms_sgrid()
-        
+
     @classmethod
     def tearDownClass(cls):
         os.remove(cls.sgrid_test_file)
-        
+
     def setUp(self):
-        self.ds = nc4.Dataset(self.sgrid_test_file)
-        
+        self.ds = Dataset(self.sgrid_test_file)
+
     def tearDown(self):
         self.ds.close()
-  
+
     def test_load_from_file(self):
         sg_obj = from_ncfile(self.sgrid_test_file)
         self.assertIsInstance(sg_obj, SGrid2D)
@@ -67,26 +67,26 @@ class TestSGridCreate(unittest.TestCase):
 class TestSGridRomsDataset(unittest.TestCase):
     """
     Test using a representative ROMS file.
-    
+
     """
     @classmethod
     def setUpClass(cls):
         cls.sgrid_test_file = roms_sgrid()
-        
+
     @classmethod
     def tearDownClass(cls):
         os.remove(cls.sgrid_test_file)
-    
+
     def setUp(self):
         self.sg_obj = from_ncfile(self.sgrid_test_file)
         self.write_path = os.path.join(CURRENT_DIR, 'test_sgrid_write.nc')
-  
+
     def test_centers(self):
         centers = self.sg_obj.centers
         centers_shape = centers.shape
         expected_shape = (4, 4, 2)
         self.assertEqual(centers_shape, expected_shape)
-    
+
     def test_variables(self):
         dataset_vars = self.sg_obj.variables
         expected_vars = [u's_rho',
@@ -112,40 +112,40 @@ class TestSGridRomsDataset(unittest.TestCase):
                          u'lon_u',
                          u'lat_v',
                          u'lon_v',
-                         u'salt', 
+                         u'salt',
                          u'zeta'
                          ]
         self.assertEqual(len(dataset_vars), len(expected_vars))
         self.assertEqual(dataset_vars, expected_vars)
-        
+
     def test_grid_variables(self):
         dataset_grid_variables = self.sg_obj.grid_variables
         expected_grid_variables = [u'u', u'v', u'fake_u', u'salt']
         self.assertEqual(len(dataset_grid_variables), len(expected_grid_variables))
         self.assertEqual(set(dataset_grid_variables), set(expected_grid_variables))
-        
+
     def test_non_grid_variables(self):
         dataset_non_grid_variables = self.sg_obj.non_grid_variables
-        expected_non_grid_variables = [u's_rho', 
-                                       u's_w', 
-                                       u'time', 
-                                       u'xi_rho', 
-                                       u'eta_rho', 
-                                       u'xi_psi', 
-                                       u'eta_psi', 
-                                       u'xi_u', 
-                                       u'eta_u', 
-                                       u'xi_v', 
-                                       u'eta_v', 
-                                       u'grid', 
-                                       u'lon_rho', 
-                                       u'lat_rho', 
-                                       u'lon_psi', 
-                                       u'lat_psi', 
-                                       u'lat_u', 
-                                       u'lon_u', 
-                                       u'lat_v', 
-                                       u'lon_v', 
+        expected_non_grid_variables = [u's_rho',
+                                       u's_w',
+                                       u'time',
+                                       u'xi_rho',
+                                       u'eta_rho',
+                                       u'xi_psi',
+                                       u'eta_psi',
+                                       u'xi_u',
+                                       u'eta_u',
+                                       u'xi_v',
+                                       u'eta_v',
+                                       u'grid',
+                                       u'lon_rho',
+                                       u'lat_rho',
+                                       u'lon_psi',
+                                       u'lat_psi',
+                                       u'lat_u',
+                                       u'lon_u',
+                                       u'lat_v',
+                                       u'lon_v',
                                        u'zeta'
                                        ]
         self.assertEqual(len(dataset_non_grid_variables), len(expected_non_grid_variables))
@@ -158,7 +158,7 @@ class TestSGridRomsDataset(unittest.TestCase):
         v_center_expected = (np.s_[:], np.s_[:], np.s_[:], np.s_[1:-1])
         self.assertEqual(u_center_slices, u_center_expected)
         self.assertEqual(v_center_slices, v_center_expected)
-        
+
     def test_grid_variable_average_axes(self):
         uc_axis = self.sg_obj.u.center_axis
         uc_axis_expected = 1
@@ -170,7 +170,7 @@ class TestSGridRomsDataset(unittest.TestCase):
         self.assertEqual(un_axis, un_axis_expected)
         self.assertIsNone(lon_rho_c_axis)
         self.assertIsNone(lon_rho_n_axis)
-        
+
     def test_optional_grid_attrs(self):
         face_coordinates = self.sg_obj.face_coordinates
         node_coordinates = self.sg_obj.node_coordinates
@@ -184,74 +184,74 @@ class TestSGridRomsDataset(unittest.TestCase):
         self.assertEqual(node_coordinates, nc_expected)
         self.assertEqual(edge1_coordinates, e1c_expected)
         self.assertEqual(edge2_coordinates, e2c_expected)
-    
-    @mock.patch('pysgrid.sgrid.nc4')
+
+    @mock.patch('pysgrid.sgrid.Dataset')
     def test_write_sgrid_to_netcdf(self, mock_nc):
         self.sg_obj.save_as_netcdf(self.write_path)
-        mock_nc.Dataset.assert_called_with(self.write_path, 'w')
-        
+        mock_nc.assert_called_with(self.write_path, 'w')
+
 
 class TestSGridNoCoordinates(unittest.TestCase):
     """
     Test to make sure that if no coordinates (e.g. face, edge1, etc)
     are specified, those coordinates can be inferred from the dataset.
-    
+
     A file is representing a delft3d dataset is used for this test.
-    
+
     """
     @classmethod
     def setUpClass(cls):
         cls.sgrid_test_file = deltares_sgrid_no_optional_attr()
-        
+
     @classmethod
     def tearDownClass(cls):
         os.remove(cls.sgrid_test_file)
-        
+
     def setUp(self):
         self.sgrid_obj = from_ncfile(self.sgrid_test_file)
-        
+
     def test_face_coordinate_inference(self):
         face_coordinates = self.sgrid_obj.face_coordinates
         expected_face_coordinates = (u'XZ', u'YZ')
         self.assertEqual(face_coordinates, expected_face_coordinates)
-        
+
     def test_grid_cell_centers(self):
         centers = self.sgrid_obj.centers
         centers_shape = (4, 4, 2)
         self.assertEqual(centers.shape, centers_shape)
-        
+
     def test_grid_cell_nodes(self):
         nodes = self.sgrid_obj.nodes
         nodes_shape = (4, 4, 2)
         self.assertEqual(nodes.shape, nodes_shape)
-        
+
     def test_grid_angles(self):
         angles = self.sgrid_obj.angles
         angles_shape = (4, 4)
         self.assertEqual(angles.shape, angles_shape)
 
-        
+
 class TestSGridWRFDataset(unittest.TestCase):
     """
     Test a representative WRF file.
-    
+
     """
     @classmethod
     def setUpClass(cls):
         cls.sgrid_test_file = wrf_sgrid_2d()
-        
+
     @classmethod
     def tearDownClass(cls):
         os.remove(cls.sgrid_test_file)
-        
+
     def setUp(self):
         self.sg_obj = from_ncfile(self.sgrid_test_file)
-        
+
     def test_topology_dimension(self):
         topology_dim = self.sg_obj.topology_dimension
         expected_dim = 2
         self.assertEqual(topology_dim, expected_dim)
-        
+
     def test_variable_slicing(self):
         u_slice = self.sg_obj.U.center_slicing
         u_expected = (np.s_[:], np.s_[:], np.s_[:], np.s_[:])
@@ -259,7 +259,7 @@ class TestSGridWRFDataset(unittest.TestCase):
         v_expected = (np.s_[:], np.s_[:], np.s_[:], np.s_[:])
         self.assertEqual(u_slice, u_expected)
         self.assertEqual(v_slice, v_expected)
-        
+
     def test_variable_average_axes(self):
         u_avg_axis = self.sg_obj.U.center_axis
         u_axis_expected = 1
@@ -267,35 +267,35 @@ class TestSGridWRFDataset(unittest.TestCase):
         v_axis_expected = 0
         self.assertEqual(u_avg_axis, u_axis_expected)
         self.assertEqual(v_avg_axis, v_axis_expected)
-        
+
 
 class TestSGridDelft3dDataset(unittest.TestCase):
     """
     Test using a representative delft3d file.
-    
+
     """
     @classmethod
     def setUpClass(cls):
         cls.sgrid_test_file = deltares_sgrid()
-        
+
     @classmethod
     def tearDownClass(cls):
         os.remove(cls.sgrid_test_file)
-    
+
     def setUp(self):
         self.sg_obj = from_ncfile(self.sgrid_test_file)
-        
+
     def test_centers(self):
         centers = self.sg_obj.centers
         centers_shape = centers.shape
         expected_shape = (4, 4, 2)
         self.assertEqual(centers_shape, expected_shape)
-        
+
     def test_topology_dimension(self):
         topology_dim = self.sg_obj.topology_dimension
         expected_dim = 2
         self.assertEqual(topology_dim, expected_dim)
-        
+
     def test_variable_slice(self):
         u_center_slices = self.sg_obj.U1.center_slicing
         v_center_slices = self.sg_obj.V1.center_slicing
@@ -309,7 +309,7 @@ class TestSGridDelft3dDataset(unittest.TestCase):
         self.assertEqual(v_center_slices, v_center_expected)
         self.assertEqual(xz_center_slices, xz_center_expected)
         self.assertEqual(xcor_center_slices, xcor_center_expected)
-        
+
     def test_averaging_axes(self):
         u1c_axis = self.sg_obj.U1.center_axis
         u1c_expected = 0
@@ -321,7 +321,7 @@ class TestSGridDelft3dDataset(unittest.TestCase):
         self.assertEqual(v1n_axis, v1n_expected)
         self.assertIsNone(latitude_c_axis)
         self.assertIsNone(latitude_n_axis)
-        
+
     def test_grid_optional_attrs(self):
         face_coordinates = self.sg_obj.face_coordinates
         node_coordinates = self.sg_obj.node_coordinates
@@ -333,17 +333,17 @@ class TestSGridDelft3dDataset(unittest.TestCase):
         self.assertEqual(node_coordinates, nc_expected)
         self.assertIsNone(edge1_coordinates)
         self.assertIsNone(edge2_coordinates)
-        
+
     def test_grid_variables(self):
         grid_variables = self.sg_obj.grid_variables
         expected_grid_variables = [u'U1', u'V1', u'FAKE_U1', u'W', u'FAKE_W']
         self.assertEqual(set(grid_variables), set(expected_grid_variables))
-        
+
     def test_angles(self):
         angles = self.sg_obj.angles
         expected_shape = (4, 4)
         self.assertEqual(angles.shape, expected_shape)
-        
+
     def test_no_3d_attributes(self):
         self.assertFalse(hasattr(self.sg_obj, 'volume_padding'))
         self.assertFalse(hasattr(self.sg_obj, 'volume_dimensions'))
@@ -359,51 +359,51 @@ class TestSGridDelft3dDataset(unittest.TestCase):
         self.assertFalse(hasattr(self.sg_obj, 'edge3_padding'))
         self.assertFalse(hasattr(self.sg_obj, 'edge3_coordinates'))
         self.assertFalse(hasattr(self.sg_obj, 'edge3_dimensions'))
-        
+
     def test_2d_attributes(self):
         self.assertTrue(hasattr(self.sg_obj, 'face_padding'))
         self.assertTrue(hasattr(self.sg_obj, 'face_coordinates'))
         self.assertTrue(hasattr(self.sg_obj, 'face_dimensions'))
         self.assertTrue(hasattr(self.sg_obj, 'vertical_padding'))
         self.assertTrue(hasattr(self.sg_obj, 'vertical_dimensions'))
-        
-        
+
+
 class TestSGridSaveNoNodeCoordinates(unittest.TestCase):
     """
     Test that SGrid.save_as_netcdf is saving content
     when there are no nodes or node coordinates specified.
-    
+
     This scenario will typically occur with WRF datasets.
-    
+
     """
     @classmethod
     def setUpClass(cls):
         cls.sgrid_test_file = wrf_sgrid_2d()
-        
+
     @classmethod
     def tearDownClass(cls):
         os.remove(cls.sgrid_test_file)
-        
+
     def setUp(self):
         self.sgrid_target = os.path.join(TEST_FILES, 'tmp_sgrid.nc')
         self.sg_obj = from_ncfile(self.sgrid_test_file)
         self.sg_obj.save_as_netcdf(self.sgrid_target)
         self.target = from_ncfile(self.sgrid_target)
-        
+
     def tearDown(self):
         os.remove(self.sgrid_target)
-        
+
     def test_sgrid(self):
         self.assertIsInstance(self.target, SGrid2D)
-        
+
     def test_nodes(self):
         nodes = self.target.nodes
         self.assertIsNone(nodes)
-        
+
     def test_node_coordinates(self):
         node_coordinates = self.target.node_coordinates
         self.assertIsNone(node_coordinates)
-        
+
     def test_node_dimesnions(self):
         node_dims = self.target.node_dimensions
         expected = 'west_east_stag south_north_stag'
@@ -414,41 +414,41 @@ class TestSGridSaveNodeCoordinates(unittest.TestCase):
     """
     Test that SGrid.save_as_netcdf is saving
     content correctly.
-    
+
     There maybe a better way to do this using
     mocks, but this will do for now.
-    
+
     """
     @classmethod
     def setUpClass(cls):
         cls.sgrid_test_file = deltares_sgrid()
-        
+
     @classmethod
     def tearDownClass(cls):
         os.remove(cls.sgrid_test_file)
-        
+
     def setUp(self):
         self.sgrid_target = os.path.join(TEST_FILES, 'tmp_sgrid.nc')
         self.sg_obj = from_ncfile(self.sgrid_test_file)
         self.sg_obj.save_as_netcdf(self.sgrid_target)
         self.target = from_ncfile(self.sgrid_target)
-        
+
     def tearDown(self):
         os.remove(self.sgrid_target)
-        
+
     def test_save_as_netcdf(self):
         """
         Test that the attributes in the
         saved netCDF file are as expected.
-        
+
         """
         target_dims = self.target.dimensions
-        expected_target_dims = [(u'MMAXZ', 4), 
-                                (u'NMAXZ', 4), 
-                                (u'MMAX', 4), 
-                                (u'NMAX', 4), 
-                                (u'KMAX', 2), 
-                                (u'KMAX1', 3), 
+        expected_target_dims = [(u'MMAXZ', 4),
+                                (u'NMAXZ', 4),
+                                (u'MMAX', 4),
+                                (u'NMAX', 4),
+                                (u'KMAX', 2),
+                                (u'KMAX1', 3),
                                 (u'time', 2)
                                 ]
         target_vars = self.target.variables
@@ -485,12 +485,12 @@ class TestSGridSaveNodeCoordinates(unittest.TestCase):
         self.assertEqual(len(target_grid_vars), len(expected_target_grid_vars))
         self.assertEqual(set(target_grid_vars), set(expected_target_grid_vars))
         self.assertEqual(target_face_coordinates, expected_target_face_coordinates)
-        
+
     def test_saved_sgrid_attributes(self):
         """
         Test that calculated/inferred attributes
         are as expected from the saved filed.
-        
+
         """
         u1_var = self.target.U1
         u1_var_center_avg_axis = u1_var.center_axis
@@ -502,76 +502,76 @@ class TestSGridSaveNodeCoordinates(unittest.TestCase):
         self.assertEqual(u1_var_center_avg_axis, expected_u1_center_axis)
         self.assertEqual(u1_vector_axis, expected_u1_vector_axis)
         np.testing.assert_almost_equal(original_angles, saved_angles, decimal=3)
-        
-        
+
+
 class Test3DimensionalSGrid(unittest.TestCase):
-    
+
     @classmethod
     def setUpClass(cls):
         cls.sgrid_test_file = wrf_sgrid()
-        
+
     @classmethod
     def tearDownClass(cls):
         os.remove(cls.sgrid_test_file)
-    
+
     def setUp(self):
         self.sg_obj = from_ncfile(self.sgrid_test_file)
-        
+
     def test_sgrid_instance(self):
         self.assertIsInstance(self.sg_obj, SGrid3D)
-        
+
     def test_variables(self):
         sg_vars = self.sg_obj.variables
         sg_vars_expected = [u'Times',
                             u'XTIME',
                             u'U',
                             u'V',
-                            u'W', 
+                            u'W',
                             u'T',
                             u'XLAT',
-                            u'XLONG', 
+                            u'XLONG',
                             u'ZNU',
                             u'ZNW',
                             u'grid'
                             ]
         self.assertEqual(len(sg_vars), len(sg_vars_expected))
         self.assertEqual(set(sg_vars), set(sg_vars_expected))
-        
+
     def test_volume_padding(self):
         volume_padding = self.sg_obj.volume_padding
-        volume_padding_expected = [GridPadding(mesh_topology_var=u'grid', face_dim=u'west_east', node_dim=u'west_east_stag', padding=u'none'), 
-                                   GridPadding(mesh_topology_var=u'grid', face_dim=u'south_north', node_dim=u'south_north_stag', padding=u'none'), 
+        volume_padding_expected = [GridPadding(mesh_topology_var=u'grid', face_dim=u'west_east', node_dim=u'west_east_stag', padding=u'none'),
+                                   GridPadding(mesh_topology_var=u'grid', face_dim=u'south_north', node_dim=u'south_north_stag', padding=u'none'),
                                    GridPadding(mesh_topology_var=u'grid', face_dim=u'bottom_top', node_dim=u'bottom_top_stag', padding=u'none')
                                    ]
         self.assertEqual(volume_padding, volume_padding_expected)
-        
+
     def test_volume_coordinates(self):
         volume_coordinates = self.sg_obj.volume_coordinates
         volume_coordinates_expected = (u'XLONG', u'XLAT', u'ZNU')
         self.assertEqual(volume_coordinates, volume_coordinates_expected)
-        
+
     def test_slicing_assignment(self):
         u_center_slice = self.sg_obj.U.center_slicing
         u_center_slice_expected = (np.s_[:], np.s_[:], np.s_[:], np.s_[:])
         self.assertEqual(u_center_slice, u_center_slice_expected)
-        
+
     def test_sgrid_centers(self):
         centers_shape = self.sg_obj.centers.shape
         expected_shape = (2, 5, 4, 2)
         self.assertEqual(centers_shape, expected_shape)
-        
+
     def test_topology_dimension(self):
         topology_dim = self.sg_obj.topology_dimension
         expected_topology_dim = 3
         self.assertEqual(topology_dim, expected_topology_dim)
-        
+
     def test_no_2d_attributes(self):
         self.assertFalse(hasattr(self.sg_obj, 'face_padding'))
         self.assertFalse(hasattr(self.sg_obj, 'face_coordinates'))
         self.assertFalse(hasattr(self.sg_obj, 'face_dimensions'))
         self.assertFalse(hasattr(self.sg_obj, 'vertical_padding'))
         self.assertFalse(hasattr(self.sg_obj, 'vertical_dimensions'))
-        
+
     def test_3d_attributes(self):
         self.assertTrue(hasattr(self.sg_obj, 'volume_padding'))
         self.assertTrue(hasattr(self.sg_obj, 'volume_dimensions'))

--- a/pysgrid/tests/test_variables.py
+++ b/pysgrid/tests/test_variables.py
@@ -6,7 +6,7 @@ Created on Apr 15, 2015
 import os
 import unittest
 
-import netCDF4 as nc4
+from netCDF4 import Dataset
 import numpy as np
 
 from ..sgrid import SGrid2D
@@ -16,35 +16,35 @@ from .write_nc_test_files import deltares_sgrid, roms_sgrid, wrf_sgrid_2d
 
 
 class TestSGridVariableROMS(unittest.TestCase):
-    
+
     @classmethod
     def setUpClass(cls):
         cls.test_file = roms_sgrid()
-        
+
     @classmethod
     def tearDownClass(cls):
         os.remove(cls.test_file)
-    
+
     def setUp(self):
-        self.face_padding = [GridPadding(mesh_topology_var=u'grid', face_dim=u'xi_rho', node_dim=u'xi_psi', padding=u'both'), 
+        self.face_padding = [GridPadding(mesh_topology_var=u'grid', face_dim=u'xi_rho', node_dim=u'xi_psi', padding=u'both'),
                              GridPadding(mesh_topology_var=u'grid', face_dim=u'eta_rho', node_dim=u'eta_psi', padding=u'both')
                              ]
         self.sgrid = SGrid2D(face_padding=self.face_padding,
                              node_dimensions='xi_psi eta_psi'
                              )
-        self.dataset = nc4.Dataset(self.test_file)
+        self.dataset = Dataset(self.test_file)
         self.test_var_1 = self.dataset.variables['u']
         self.test_var_2 = self.dataset.variables['zeta']
         self.test_var_3 = self.dataset.variables['salt']
         self.test_var_4 = self.dataset.variables['fake_u']
-        
+
     def tearDown(self):
         self.dataset.close()
-        
+
     def test_create_sgrid_variable_object(self):
         sgrid_var = SGridVariable.create_variable(self.test_var_1, self.sgrid)
         self.assertIsInstance(sgrid_var, SGridVariable)
-        
+
     def test_attributes_with_grid(self):
         sgrid_var = SGridVariable.create_variable(self.test_var_1, self.sgrid)
         sgrid_var_name = sgrid_var.variable
@@ -75,20 +75,20 @@ class TestSGridVariableROMS(unittest.TestCase):
         self.assertIsNone(z_axis)
         self.assertEqual(standard_name, expected_standard_name)
         self.assertEqual(coordinates, expected_coordinates)
-        
+
     def test_face_location_inference(self):
         sgrid_var = SGridVariable.create_variable(self.test_var_3, self.sgrid)
         sgrid_var_location = sgrid_var.location
         expected_location = 'face'
         self.assertEqual(sgrid_var_location, expected_location)
-        
+
     def test_edge_location_inference(self):
         sgrid_var = SGridVariable.create_variable(self.test_var_4, self.sgrid)
         sgrid_var_location = sgrid_var.location
         # representative ROMS sgrid
         # None is expected since edge1 and edge2 attributes are not defined
         self.assertIsNone(sgrid_var_location)
-        
+
     def test_edge_location_inference_with_defined_edges(self):
         self.sgrid.edge1_padding = [GridPadding(mesh_topology_var=u'grid', face_dim=u'eta_u', node_dim=u'eta_psi', padding=u'both')]
         self.sgrid.edge2_padding = [GridPadding(mesh_topology_var=u'grid', face_dim=u'xi_v', node_dim=u'xi_psi', padding=u'both')]
@@ -96,7 +96,7 @@ class TestSGridVariableROMS(unittest.TestCase):
         sgrid_var_location = sgrid_var.location
         expected_location = 'edge1'
         self.assertEqual(sgrid_var_location, expected_location)
-        
+
     def test_attributes_with_location(self):
         sgrid_var = SGridVariable.create_variable(self.test_var_2, self.sgrid)
         sgrid_var_name = sgrid_var.variable
@@ -118,7 +118,7 @@ class TestSGridVariableROMS(unittest.TestCase):
         self.assertIsNone(x_axis)
         self.assertIsNone(y_axis)
         self.assertIsNone(z_axis)
-        
+
     def test_vector_directions(self):
         u_var = SGridVariable.create_variable(self.test_var_1, self.sgrid)
         u_vector_axis = u_var.vector_axis
@@ -127,18 +127,18 @@ class TestSGridVariableROMS(unittest.TestCase):
         zeta_axis = zeta_var.vector_axis
         self.assertEqual(u_vector_axis, expected_u_axis)
         self.assertIsNone(zeta_axis)
-        
+
 
 class TestSGridVariablesWRF(unittest.TestCase):
-    
+
     @classmethod
     def setUpClass(cls):
         cls.test_file = wrf_sgrid_2d()
-        
+
     @classmethod
     def tearDownClass(cls):
         os.remove(cls.test_file)
-        
+
     def setUp(self):
         self.face_padding = [GridPadding(mesh_topology_var=u'grid', face_dim=u'west_east', node_dim=u'west_east_stag', padding=u'none'),
                              GridPadding(mesh_topology_var=u'grid', face_dim=u'south_north', node_dim=u'south_north_stag', padding=u'none')
@@ -147,36 +147,36 @@ class TestSGridVariablesWRF(unittest.TestCase):
         self.sgrid = SGrid2D(face_padding=self.face_padding,
                              node_dimensions=self.node_dimensions
                              )
-        self.dataset = nc4.Dataset(self.test_file)
+        self.dataset = Dataset(self.test_file)
         self.test_var_1 = self.dataset.variables['SNOW']
         self.test_var_2 = self.dataset.variables['FAKE_U']
-        
+
     def tearDown(self):
         self.dataset.close()
-        
+
     def test_face_location_inference(self):
         sg_var = SGridVariable.create_variable(self.test_var_1, self.sgrid)
         sg_var_location = sg_var.location
         expected_location = 'face'
         self.assertEqual(sg_var_location, expected_location)
-        
+
     def test_edge_location_inference(self):
         sg_var = SGridVariable.create_variable(self.test_var_2, self.sgrid)
         sg_var_location = sg_var.location
         expected_location = 'edge1'
         self.assertEqual(sg_var_location, expected_location)
-        
-        
+
+
 class TestSGridVariablesDeltares(unittest.TestCase):
-    
+
     @classmethod
     def setUpClass(cls):
         cls.test_file = deltares_sgrid()
-        
+
     @classmethod
     def tearDownClass(cls):
         os.remove(cls.test_file)
-        
+
     def setUp(self):
         self.face_padding = [GridPadding(mesh_topology_var=u'grid', face_dim=u'MMAXZ', node_dim=u'MMAX', padding=u'low'),
                              GridPadding(mesh_topology_var=u'grid', face_dim=u'NMAXZ', node_dim=u'NMAX', padding=u'low')
@@ -185,19 +185,19 @@ class TestSGridVariablesDeltares(unittest.TestCase):
         self.sgrid = SGrid2D(face_padding=self.face_padding,
                              node_dimensions=self.node_dimensions
                              )
-        self.dataset = nc4.Dataset(self.test_file)
+        self.dataset = Dataset(self.test_file)
         self.test_var_1 = self.dataset.variables['FAKE_W']
         self.test_var_2 = self.dataset.variables['FAKE_U1']
-        
+
     def tearDown(self):
         self.dataset.close()
-        
+
     def test_face_location_inference(self):
         sg_var = SGridVariable.create_variable(self.test_var_1, self.sgrid)
         sg_var_location = sg_var.location
         expected_location = 'face'
         self.assertEqual(sg_var_location, expected_location)
-        
+
     def test_edge_location_inference(self):
         sg_var = SGridVariable.create_variable(self.test_var_2, self.sgrid)
         sg_var_location = sg_var.location

--- a/pysgrid/tests/write_nc_test_files.py
+++ b/pysgrid/tests/write_nc_test_files.py
@@ -4,7 +4,7 @@ Created on Apr 7, 2015
 @author: ayan
 '''
 import os
-import netCDF4 as nc4
+from netCDF4 import Dataset
 import numpy as np
 from pysgrid.lookup import (LON_GRID_CELL_CENTER_LONG_NAME, LAT_GRID_CELL_CENTER_LONG_NAME,
                             LON_GRID_CELL_NODE_LONG_NAME, LAT_GRID_CELL_NODE_LONG_NAME)
@@ -15,7 +15,7 @@ TEST_FILES = os.path.join(os.path.split(__file__)[0], 'files')
 
 def simulated_dgrid(target_dir=TEST_FILES, nc_filename='fake_dgrid.nc'):
     file_name = os.path.join(target_dir, nc_filename)
-    with nc4.Dataset(file_name, 'w') as rg:
+    with Dataset(file_name, 'w') as rg:
         # define dims
         rg.createDimension('MMAXZ', 4)
         rg.createDimension('NMAXZ', 4)
@@ -23,7 +23,7 @@ def simulated_dgrid(target_dir=TEST_FILES, nc_filename='fake_dgrid.nc'):
         rg.createDimension('NMAX', 4)
         rg.createDimension('KMAX', 2)
         rg.createDimension('KMAX1', 3)
-        rg.createDimension('time', 2)     
+        rg.createDimension('time', 2)
         # define vars
         xcor = rg.createVariable('XCOR', 'f4', ('MMAX', 'NMAX'))
         ycor = rg.createVariable('YCOR', 'f4', ('MMAX', 'NMAX'))
@@ -55,11 +55,11 @@ def simulated_dgrid(target_dir=TEST_FILES, nc_filename='fake_dgrid.nc'):
         u1[:] = np.random.random((2, 2, 4, 4))
         v1[:] = np.random.random((2, 2, 4, 4))
         times[:] = np.random.random((2,))
-        
-        
+
+
 def deltares_sgrid_no_optional_attr(target_dir=TEST_FILES, nc_filename='test_sgrid_deltares_no_optional_attr.nc'):
     file_name = os.path.join(target_dir, nc_filename)
-    with nc4.Dataset(file_name, 'w') as rg:
+    with Dataset(file_name, 'w') as rg:
         # define dimensions
         rg.createDimension('MMAXZ', 4)
         rg.createDimension('NMAXZ', 4)
@@ -110,17 +110,17 @@ def deltares_sgrid_no_optional_attr(target_dir=TEST_FILES, nc_filename='test_sgr
         v1[:] = np.random.random((2, 2, 4, 4))
         times[:] = np.random.random((2,))
     return file_name
-       
+
 
 def deltares_sgrid(target_dir=TEST_FILES, nc_filename='test_sgrid_deltares.nc'):
     """
     Create a netCDF file that is structurally similar to
     deltares output. Dimension and variable names may differ
     from an actual file.
-    
+
     """
     file_name = os.path.join(target_dir, nc_filename)
-    with nc4.Dataset(file_name, 'w') as rg:
+    with Dataset(file_name, 'w') as rg:
         # define dimensions
         rg.createDimension('MMAXZ', 4)
         rg.createDimension('NMAXZ', 4)
@@ -188,17 +188,17 @@ def deltares_sgrid(target_dir=TEST_FILES, nc_filename='test_sgrid_deltares.nc'):
         w[:] = np.random.random((2, 3, 4, 4))
         fake_w[:] = np.random.random((2, 4, 4))
     return file_name
-        
-        
+
+
 def roms_sgrid(target_dir=TEST_FILES, nc_filename='test_sgrid_roms.nc'):
     """
     Create a netCDF file that is structurally similar to
     ROMS output. Dimension and variable names may differ
     from an actual file.
-    
+
     """
     file_name = os.path.join(target_dir, nc_filename)
-    with nc4.Dataset(file_name, 'w') as rg:
+    with Dataset(file_name, 'w') as rg:
         # set dimensions
         rg.createDimension('s_rho', 2)
         rg.createDimension('s_w', 3)
@@ -266,7 +266,7 @@ def roms_sgrid(target_dir=TEST_FILES, nc_filename='test_sgrid_roms.nc'):
         zeta.coordinates = 'time lat_rho lon_rho'
         u.grid = 'some grid'
         u.axes = 'X: xi_u Y: eta_u'
-        u.coordinates = 'time s_rho lat_u lon_u ' 
+        u.coordinates = 'time s_rho lat_u lon_u '
         u.location = 'edge1'
         u.standard_name = 'sea_water_x_velocity'
         v.grid = 'some grid'
@@ -298,7 +298,7 @@ def roms_sgrid(target_dir=TEST_FILES, nc_filename='test_sgrid_roms.nc'):
 
 def wrf_sgrid_2d(target_dir=TEST_FILES, nc_filename='test_sgrid_wrf_2.nc'):
     file_name = os.path.join(target_dir, nc_filename)
-    with nc4.Dataset(file_name, 'w') as nc:
+    with Dataset(file_name, 'w') as nc:
         nc.createDimension('Time', 2)
         nc.createDimension('DateStrLen', 3)
         nc.createDimension('west_east', 4)
@@ -354,15 +354,15 @@ def wrf_sgrid_2d(target_dir=TEST_FILES, nc_filename='test_sgrid_wrf_2.nc'):
         znus[:, :] = np.random.random(size=(2, 3))
         znws[:, :] = np.random.random(size=(2, 4))
     return file_name
-        
-        
+
+
 def wrf_sgrid(target_dir=TEST_FILES, nc_filename='test_sgrid_wrf.nc'):
     """
     Write an SGrid file using 3D conventions.
-    
+
     """
     file_name = os.path.join(target_dir, nc_filename)
-    with  nc4.Dataset(file_name, 'w') as fg:
+    with  Dataset(file_name, 'w') as fg:
         # create dimensions
         fg.createDimension('Time', 2)
         fg.createDimension('DateStrLen', 3)
@@ -412,17 +412,17 @@ def wrf_sgrid(target_dir=TEST_FILES, nc_filename='test_sgrid_wrf.nc'):
         znus[:, :] = np.random.random(size=(2, 3))
         znws[:, :] = np.random.random(size=(2, 4))
     return file_name
-        
-               
+
+
 def non_compliant_sgrid(target_dir=TEST_FILES, nc_filename='test_noncompliant_sgrid.nc'):
     """
     Create a netCDF file that is structurally similar to
     ROMS output. Dimension and variable names may differ
     from an actual file.
-    
+
     """
     file_name = os.path.join(target_dir, nc_filename)
-    with nc4.Dataset(file_name, 'w') as rg:
+    with Dataset(file_name, 'w') as rg:
         # set dimensions
         rg.createDimension('z_center', 2)
         rg.createDimension('z_node', 3)
@@ -486,7 +486,7 @@ def non_compliant_sgrid(target_dir=TEST_FILES, nc_filename='test_noncompliant_sg
         x_vs[:] = np.random.random(size=(4,))
         y_vs[:] = np.random.random(size=(3,))
         u[:, :, :, :] = np.random.random(size=(2, 2, 4, 3))  # x-directed velocities
-        v[:] = np.random.random(size=(2, 2, 3, 4))  # y-directed velocities 
+        v[:] = np.random.random(size=(2, 2, 3, 4))  # y-directed velocities
         lat_u[:] = np.random.random(size=(4, 3))
         lon_u[:] = np.random.random(size=(4, 3))
         lat_v[:] = np.random.random(size=(3, 4))

--- a/pysgrid/utils.py
+++ b/pysgrid/utils.py
@@ -20,16 +20,16 @@ def pair_arrays(x_array, y_array):
     """
     Given two arrays to equal dimensions,
     pair their values element-wise.
-    
+
     For example given arrays [[1, 2], [3, 4]]
     and [[-1, -2], [-3, -4]], this function will
     return [[[1, -1], [2, -2]], [[3, -3], [4, -4]]].
-    
+
     :param np.array x_array: a numpy array containing "x" coordinates
     :param np.array y_array: a numpy array containing "y" coordinates
     :return: array containing (x, y) arrays
     :rtype: np.array
-    
+
     """
     x_shape = x_array.shape
     paired_array_shape = x_shape + (2,)
@@ -43,12 +43,12 @@ def check_element_equal(lst):
     """
     Check that all elements in an
     iterable are the same.
-    
+
     :params lst: iterable object to be checked
     :type lst: np.array, list, tuple
     :return: result of element equality check
     :rtype: bool
-    
+
     """
     return lst[1:] == lst[:-1]
 
@@ -74,7 +74,7 @@ def determine_variable_slicing(sgrid_obj, nc_variable, method='center'):
     only knows who to figure out slices that would be
     used to trim data before averaging to grid cell
     centers; grid cell nodes will be supported later.
-    
+
     :param sgrid_obj: an SGrid object derived from a netCDF file or netCDF4.Dataset object
     :type sgrid_obj: sgrid.SGrid
     :param nc_dataset: a netCDF4.Dataset object from which the sgrid_obj was derived
@@ -83,7 +83,7 @@ def determine_variable_slicing(sgrid_obj, nc_variable, method='center'):
     :param str method: slice method for analysis at grid cell centers or grid cell nodes; accepts either 'center' or 'node'
     :return: the slice for the varible for the given method
     :rtype: tuple
-    
+
     """
     grid_variables = sgrid_obj.grid_variables
     if grid_variables is None:
@@ -122,7 +122,7 @@ def infer_avg_axes(sgrid_obj, nc_var_obj):
     Infer which numpy axis to average over given
     the a variable defined on the grid. Works
     well for 2D. Not so sure about 3D.
-    
+
     """
     var_dims = nc_var_obj.dimensions
     node_dimensions = tuple(sgrid_obj.node_dimensions.split(' '))
@@ -180,7 +180,7 @@ def infer_variable_location(sgrid, variable):
 def calculate_bearing(lon_lat_1, lon_lat_2):
     """
     return bearing from true north in degrees
-    
+
     """
     lon_lat_1_radians = lon_lat_1 * np.pi/180
     lon_lat_2_radians = lon_lat_2 * np.pi/180
@@ -198,14 +198,14 @@ def calculate_bearing(lon_lat_1, lon_lat_2):
 def calculate_angle_from_true_east(lon_lat_1, lon_lat_2):
     """
     Return the angle from true east in radians
-    
+
     """
     bearing = calculate_bearing(lon_lat_1, lon_lat_2)
     bearing_from_true_east = 90 - bearing
     bearing_from_true_east_radians = bearing_from_true_east * np.pi/180
     # not sure if this is the most appropriate thing to do for the last grid cell
-    angles = np.append(bearing_from_true_east_radians, 
-                       bearing_from_true_east_radians[..., -1:], 
+    angles = np.append(bearing_from_true_east_radians,
+                       bearing_from_true_east_radians[..., -1:],
                        axis=-1
                        )
     return angles

--- a/pysgrid/variables.py
+++ b/pysgrid/variables.py
@@ -9,11 +9,11 @@ from .utils import determine_variable_slicing, infer_avg_axes, infer_variable_lo
 
 class SGridVariable(object):
     """
-    Object of variables found and inferred 
+    Object of variables found and inferred
     from an SGRID compliant dataset.
-    
+
     """
-    def __init__(self, 
+    def __init__(self,
                  center_axis=None,
                  center_slicing=None,
                  coordinates=None,
@@ -44,7 +44,7 @@ class SGridVariable(object):
         self.x_axis = x_axis
         self.y_axis = y_axis
         self.z_axis = z_axis
-        
+
     @classmethod
     def create_variable(cls, nc_var_obj, sgrid_obj):
         variable = nc_var_obj.name
@@ -56,8 +56,8 @@ class SGridVariable(object):
             node_axis = None
         else:
             center_axis, node_axis = infer_avg_axes(sgrid_obj, nc_var_obj)
-        center_slicing = determine_variable_slicing(sgrid_obj, 
-                                                    nc_var_obj, 
+        center_slicing = determine_variable_slicing(sgrid_obj,
+                                                    nc_var_obj,
                                                     method='center'
                                                     )
         dimensions = nc_var_obj.dimensions


### PR DESCRIPTION
There is a lot of noise in this PR due to some blank spaces removal.  But this tiny PR changes only how the `netCDF4.Dataset` class is imported.

Two advantages:
- lower the entry barrier for new contributors by [avoiding renaming](https://youtu.be/o5D8DwvkOc8) `netCDF4` to a non-standard `nc4`,
- small performance improvement since we have [1 less name to lookup](http://stackoverflow.com/questions/3591962/python-import-x-or-from-x-import-y-performance).