### PR TITLE
Faster travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,25 @@
 language: python
-python:
-    - "2.7"
-    - "3.4"
-sudo: required
-# command to install dependencies
+
+sudo: false
+
+env:
+    - PYTHON="2.7"
+    - PYTHON="3.3"
+    - PYTHON="3.4"
+    - PYTHON="3.5"
+
 before_install:
-    - sudo apt-get update -qq
-    - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-        wget http://repo.continuum.io/miniconda/Miniconda-3.9.1-Linux-x86_64.sh -O miniconda.sh;
-      else
-        wget http://repo.continuum.io/miniconda/Miniconda3-3.9.1-Linux-x86_64.sh -O miniconda.sh;
-      fi
+    - wget http://bit.ly/miniconda -O miniconda.sh
     - bash miniconda.sh -b -p $HOME/miniconda
     - export PATH="$HOME/miniconda/bin:$PATH"
-    - hash -r
-    - conda config --set always_yes yes --set changeps1 no
-    - conda update -q conda
-    - conda info -a
-    - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
-    - source activate test-environment
-install:
-    - conda install --quiet --file requirements.txt
-    - conda install --quiet --file requirements-test.txt
-# command to run tests
-script: nosetests
+    - conda update --yes --all
+    - travis_retry conda create --yes -n test python=$PYTHON --file requirements.txt
+    - source activate test
+    - travis_retry conda install --yes nose
+    - if [[ "$PYTHON" != "3.5" ]]; then
+        travis_retry conda install --yes mock ;
+      fi
+    - travis_retry pip install
+
+script:
+    - nosetests

--- a/pysgrid/tests/test_sgrid.py
+++ b/pysgrid/tests/test_sgrid.py
@@ -6,7 +6,11 @@ Created on Apr 7, 2015
 import os
 import unittest
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
 from netCDF4 import Dataset
 import numpy as np
 


### PR DESCRIPTION
- Move away from Travis-CI legacy infrastructure
- Adds tests for python 3.3 and 3.5

PS: Ignore the white space noise in `pysgrid/tests/test_sgrid.py`.  The important change is (for Python 3.5):

```python
try:
    from unittest import mock
except ImportError:
    import mock
```