### PR TITLE
Cell Tree, Index translation, and Bilinear Interpolation

### DIFF
--- a/notebooks/Sgrid Interpolation Demo.ipynb
+++ b/notebooks/Sgrid Interpolation Demo.ipynb
@@ -170,7 +170,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 13,
    "metadata": {
     "collapsed": false
    },
@@ -184,12 +184,13 @@
       " 23.44884449221559 23.45918945470487]\n",
       "[43.41301646604848 43.40833575274081 43.4036551192405 43.39897456556031\n",
       " 43.394294092083555 43.41151307230791 43.40683296250011 43.4021529311478\n",
-      " 43.39747298010166 43.39279310876989]\n"
+      " 43.39747298010166 43.39279310876989]\n",
+      "Wall time: 18 ms\n"
      ]
     }
    ],
    "source": [
-    "\n",
+    "%%time\n",
     "interp_temps = sgrid.interpolate_var_to_points(points, sgrid.temp[0,6])\n",
     "interp_salinity = sgrid.interpolate_var_to_points(points, sgrid.salt[0,6])\n",
     "\n",
@@ -301,7 +302,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "metadata": {
     "collapsed": false
    },
@@ -315,11 +316,13 @@
       " 23.44884449221559 23.45918945470487]\n",
       "[43.41301646604848 43.40833575274081 43.4036551192405 43.39897456556031\n",
       " 43.394294092083555 43.41151307230791 43.40683296250011 43.4021529311478\n",
-      " 43.39747298010166 43.39279310876989]\n"
+      " 43.39747298010166 43.39279310876989]\n",
+      "Wall time: 13 ms\n"
      ]
     }
    ],
    "source": [
+    "%%time\n",
     "indices = sgrid.locate_faces(points)\n",
     "\n",
     "#re-use these variables if you plan to interpolate to the same points repeatedly\n",

--- a/notebooks/Sgrid Interpolation Demo.ipynb
+++ b/notebooks/Sgrid Interpolation Demo.ipynb
@@ -1,0 +1,363 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Pysgrid Interpolation Demo \n",
+    " \n",
+    "Lets start with the pysgrid object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from netCDF4 import Dataset\n",
+    "import pysgrid\n",
+    "import numpy as np\n",
+    "\n",
+    "url = ('http://geoport.whoi.edu/thredds/dodsC/clay/usgs/users/'\n",
+    "               'jcwarner/Projects/Sandy/triple_nest/00_dir_NYB05.ncml')\n",
+    "\n",
+    "sgrid = pysgrid.load_grid(Dataset(url))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Pysgrid variable objects can now serve data, similar to pyugrid variables. It calls directly on the netCDF Variable object, and has it's lazy-loading behavior."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SGridVariable object: sea_water_potential_temperature, on the faces\n",
+      "(201, 16, 107, 345)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print sgrid.temp\n",
+    "print sgrid.temp.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[ 18.07930946,  18.14973068,  18.2201519 ,  18.21634102,\n",
+       "         18.21252823],\n",
+       "       [ 18.15918732,  18.22960854,  18.30002975,  18.29621696,\n",
+       "         18.29240417],\n",
+       "       [ 18.23906708,  18.30948639,  18.37990761,  18.37609482,\n",
+       "         18.32413864],\n",
+       "       [ 18.31894493,  18.38936615,  18.45978546,  18.40782738,\n",
+       "         18.35586929],\n",
+       "       [ 18.45632744,  18.52674675,  18.50500488,  18.4530468 ,\n",
+       "         18.40108871]], dtype=float32)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sgrid.temp[0,0,50:55,100:105]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First lets establish some points on the grid we're interested in. For simplicity, we'll derive them from the grid nodes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[-73.74568073  40.32299155]\n",
+      " [-73.7391676   40.32583585]\n",
+      " [-73.73265448  40.32868015]\n",
+      " [-73.72614136  40.33152445]\n",
+      " [-73.71962823  40.33436874]\n",
+      " [-73.74901747  40.33079974]\n",
+      " [-73.7425043   40.33364399]\n",
+      " [-73.73599114  40.33648823]\n",
+      " [-73.72947797  40.33933248]\n",
+      " [-73.72296481  40.34217672]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "points_lon = sgrid.node_lon[50:52,100:105] * 0.9999\n",
+    "points_lat = sgrid.node_lat[50:52,100:105] * 0.9999\n",
+    "points = np.stack((points_lon, points_lat), axis = -1).reshape(-1,2)\n",
+    "print points"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The SGrid object now provides a way to get the x,y indices of these points on the node grid. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[ 49 100]\n",
+      " [ 49 101]\n",
+      " [ 49 102]\n",
+      " [ 49 103]\n",
+      " [ 49 104]\n",
+      " [ 50 100]\n",
+      " [ 50 101]\n",
+      " [ 50 102]\n",
+      " [ 50 103]\n",
+      " [ 50 104]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "node_ind = sgrid.locate_faces(points)\n",
+    "print node_ind"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Scenario: I want to interpolate the temperature and salinity at a list of points."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[23.40559527721179 23.391546600118488 23.41423669831296 23.436921401441918\n",
+      " 23.45776700834991 23.419357486410757 23.4053081701454 23.427996148979414\n",
+      " 23.44884449221559 23.45918945470487]\n",
+      "[43.41301646604848 43.40833575274081 43.4036551192405 43.39897456556031\n",
+      " 43.394294092083555 43.41151307230791 43.40683296250011 43.4021529311478\n",
+      " 43.39747298010166 43.39279310876989]\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "interp_temps = sgrid.interpolate_var_to_points(points, sgrid.temp[0,6])\n",
+    "interp_salinity = sgrid.interpolate_var_to_points(points, sgrid.salt[0,6])\n",
+    "\n",
+    "print interp_temps\n",
+    "print interp_salinity"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Done!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Interpolating for a vector quantity like velocity is a bit more complicated, but the same approach can be used piecewise."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[ 0.02588658 -0.19636827]\n",
+      " [ 0.02969118 -0.19708817]\n",
+      " [ 0.03296548 -0.19143968]\n",
+      " [ 0.03621145 -0.18579166]\n",
+      " [ 0.03945695 -0.1801441 ]\n",
+      " [ 0.03022276 -0.19490993]\n",
+      " [ 0.03349701 -0.19477434]\n",
+      " [ 0.03674293 -0.18912618]\n",
+      " [ 0.03998839 -0.18347849]\n",
+      " [ 0.04323336 -0.17783126]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "interp_u = sgrid.interpolate_var_to_points(points, sgrid.u[0,6])\n",
+    "interp_v = sgrid.interpolate_var_to_points(points, sgrid.v[0,6])\n",
+    "print np.column_stack((interp_u, interp_v))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Trying to interpolate to points outside the grid will return nans."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[-1 -1]\n",
+      " [-1 -1]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "bad_pts = np.array(([0,0],[1,1]))\n",
+    "bad_ind = sgrid.locate_faces(bad_pts)\n",
+    "print bad_ind"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[nan nan]\n"
+     ]
+    }
+   ],
+   "source": [
+    "interp_u = sgrid.interpolate_var_to_points(bad_pts, sgrid.u[0,6])\n",
+    "print interp_u"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you are interpolating multiple variables at the same time or interpolating to the same points repeatedly, you can save considerable computation by pre-computing some information for interpolate_var_to_points."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[23.40559527721179 23.391546600118488 23.41423669831296 23.436921401441918\n",
+      " 23.45776700834991 23.419357486410757 23.4053081701454 23.427996148979414\n",
+      " 23.44884449221559 23.45918945470487]\n",
+      "[43.41301646604848 43.40833575274081 43.4036551192405 43.39897456556031\n",
+      " 43.394294092083555 43.41151307230791 43.40683296250011 43.4021529311478\n",
+      " 43.39747298010166 43.39279310876989]\n"
+     ]
+    }
+   ],
+   "source": [
+    "indices = sgrid.locate_faces(points)\n",
+    "center_inds = sgrid.translate_index(points, indices, sgrid.center_lon, sgrid.center_lat, 'face')\n",
+    "interp_alphas = sgrid.interpolation_alphas(points, center_inds, sgrid.center_lon, sgrid.center_lat)\n",
+    "\n",
+    "interp_temps = sgrid.interpolate_var_to_points(points, sgrid.temp[0,6], center_inds, interp_alphas)\n",
+    "interp_salinity = sgrid.interpolate_var_to_points(points, sgrid.salt[0,6], center_inds, interp_alphas)\n",
+    "\n",
+    "print interp_temps\n",
+    "print interp_salinity"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/notebooks/Sgrid Interpolation Demo.ipynb
+++ b/notebooks/Sgrid Interpolation Demo.ipynb
@@ -319,8 +319,10 @@
    ],
    "source": [
     "indices = sgrid.locate_faces(points)\n",
-    "center_inds = sgrid.translate_index(points, indices, sgrid.center_lon, sgrid.center_lat, 'face')\n",
-    "interp_alphas = sgrid.interpolation_alphas(points, center_inds, sgrid.center_lon, sgrid.center_lat)\n",
+    "\n",
+    "#re-use these variables if you plan to interpolate to the same points repeatedly\n",
+    "center_inds = sgrid.translate_index(points, indices, 'center')\n",
+    "interp_alphas = sgrid.interpolation_alphas(points, center_inds, 'center')\n",
     "\n",
     "interp_temps = sgrid.interpolate_var_to_points(points, sgrid.temp[0,6], center_inds, interp_alphas)\n",
     "interp_salinity = sgrid.interpolate_var_to_points(points, sgrid.salt[0,6], center_inds, interp_alphas)\n",

--- a/notebooks/Sgrid Interpolation Demo.ipynb
+++ b/notebooks/Sgrid Interpolation Demo.ipynb
@@ -213,7 +213,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 11,
    "metadata": {
     "collapsed": false
    },
@@ -231,11 +231,13 @@
       " [ 0.03349701 -0.19477434]\n",
       " [ 0.03674293 -0.18912618]\n",
       " [ 0.03998839 -0.18347849]\n",
-      " [ 0.04323336 -0.17783126]]\n"
+      " [ 0.04323336 -0.17783126]]\n",
+      "Wall time: 22 ms\n"
      ]
     }
    ],
    "source": [
+    "%%time\n",
     "interp_u = sgrid.interpolate_var_to_points(points, sgrid.u[0,6])\n",
     "interp_v = sgrid.interpolate_var_to_points(points, sgrid.v[0,6])\n",
     "print np.column_stack((interp_u, interp_v))"

--- a/pysgrid/sgrid.py
+++ b/pysgrid/sgrid.py
@@ -57,6 +57,10 @@ class SGrid(object):
         self.node_lat = node_lat
         self.center_lon = center_lon
         self.center_lat = center_lat
+        self.edge1_lon = edge1_lon
+        self.edge1_lat = edge1_lat
+        self.edge2_lon = edge2_lon
+        self.edge2_lat = edge2_lat
         self.edges = edges
         self.node_padding = node_padding
         self.edge1_padding = edge1_padding

--- a/pysgrid/sgrid.py
+++ b/pysgrid/sgrid.py
@@ -309,6 +309,7 @@ class SGrid(object):
         node_x = indices % (self.node_lat.shape[1] - 1)
         node_y = indices // (self.node_lat.shape[1] - 1)
         node_ind = np.column_stack((node_y, node_x))
+        node_ind[node_ind[:, 0] == -1] = [-1, -1]
         if just_one:
             return node_ind[0]
         else:
@@ -377,6 +378,7 @@ class SGrid(object):
         if mask is not None:
             # REVISIT LATER
             result.mask = mask[ind[:, 0], ind[:, 1]]
+        result[np.where(ind[:, 0] == -1)] = [np.nan, ]
         return result
 
     def infer_grid(self, variable):
@@ -407,6 +409,10 @@ class SGrid(object):
             x = index[:, 0]
             y = index[:, 1]
             return np.stack((var[x, y], var[x + 1, y], var[x + 1, y + 1], var[x, y + 1]), axis=1)
+
+        if type(lons) is not np.ndarray or type(lats) is not np.ndarray:
+            lons = lons[:]
+            lats = lats[:]
 
         translations = {'face': np.array([[0, 0], [1, 0], [0, 1], [1, 1]]),
                         'edge1': np.array([[1, 0], [0, 0], [1, 1], [0, 1], [1, -1], [0, -1]]),
@@ -471,7 +477,7 @@ class SGrid(object):
             b = np.dot(AI, py.getH())
             return (np.array(a), np.array(b))
 
-        def x_tp_l(x, y, a, b):
+        def x_to_l(x, y, a, b):
             """
             Params:
             a: x coefficients

--- a/pysgrid/utils.py
+++ b/pysgrid/utils.py
@@ -104,8 +104,8 @@ def determine_variable_slicing(sgrid_obj, nc_variable, method='center'):
     if method == 'center':
         for var_dim in var_dims:
             try:
-                padding_info = next((info for info in padding if
-                                     info.face_dim == var_dim))
+                padding_info = next(
+                    (info for info in padding if info.face_dim == var_dim))
             except StopIteration:
                 slice_index = np.s_[:]
                 slice_indices += (slice_index,)
@@ -171,7 +171,7 @@ def infer_variable_location(sgrid, variable):
         edge_dims = []
     var_dims = variable.dimensions
     if (does_intersection_exist(var_dims, face_dims) and not
-       does_intersection_exist(var_dims, node_dims)):
+            does_intersection_exist(var_dims, node_dims)):
         inferred_location = 'face'
     elif ((does_intersection_exist(var_dims, face_dims) and
            does_intersection_exist(var_dims, node_dims)) or
@@ -187,16 +187,16 @@ def calculate_bearing(lon_lat_1, lon_lat_2):
     return bearing from true north in degrees
 
     """
-    lon_lat_1_radians = lon_lat_1 * np.pi/180
-    lon_lat_2_radians = lon_lat_2 * np.pi/180
+    lon_lat_1_radians = lon_lat_1 * np.pi / 180
+    lon_lat_2_radians = lon_lat_2 * np.pi / 180
     lon_1 = lon_lat_1_radians[..., 0]
     lat_1 = lon_lat_1_radians[..., 1]
     lon_2 = lon_lat_2_radians[..., 0]
     lat_2 = lon_lat_2_radians[..., 1]
-    x1 = np.sin(lon_2-lon_1) * np.cos(lat_2)
-    x2 = np.cos(lat_1)*np.sin(lat_2) - np.sin(lat_1)*np.cos(lat_2)*np.cos(lon_2-lon_1)  # noqa
+    x1 = np.sin(lon_2 - lon_1) * np.cos(lat_2)
+    x2 = np.cos(lat_1) * np.sin(lat_2) - np.sin(lat_1) * np.cos(lat_2) * np.cos(lon_2 - lon_1)  # noqa
     bearing_radians = np.arctan2(x1, x2)
-    bearing_degrees = bearing_radians * 180/np.pi
+    bearing_degrees = bearing_radians * 180 / np.pi
     return (bearing_degrees + 360) % 360
 
 
@@ -207,9 +207,93 @@ def calculate_angle_from_true_east(lon_lat_1, lon_lat_2):
     """
     bearing = calculate_bearing(lon_lat_1, lon_lat_2)
     bearing_from_true_east = 90 - bearing
-    bearing_from_true_east_radians = bearing_from_true_east * np.pi/180
-    # Unsure if this is the appropriate thing to do for the last grid cell.
+    bearing_from_true_east_radians = bearing_from_true_east * np.pi / 180
+    # not sure if this is the most appropriate thing to do for the last grid
+    # cell
     angles = np.append(bearing_from_true_east_radians,
                        bearing_from_true_east_radians[..., -1:],
                        axis=-1)
     return angles
+
+
+def translate_index(points, ind, dest_grid, translation=None):
+    """
+    :param points: Array of points on grid 1
+    :param ind: Array of x,y indicices of the points on grid 1
+    :param grid1: SGrid representing the source grid
+    :param dest_grid: SGrid representing the destination grid
+    Takes two sgrid objects and a list of x,y indices on grid 1
+    Translates the indices to what they would be on the other grid
+    """
+
+    def s_poly(index, var):
+        x = index[:, 0]
+        y = index[:, 1]
+        return np.stack((var[x, y], var[x + 1, y], var[x + 1, y + 1], var[x, y + 1]), axis=1)
+
+    translations = {'psi2rho': np.array([[0, 0], [1, 0], [0, 1], [1, 1]]),
+                    'u2v': np.array([[0, 0], [0, -1], [1, 0], [1, -1]]),
+                    'u2rho': np.array([[0, 0], [0, 1], [-1, 0], [-1, 1], [1, 0], [1, 1]]),
+                    'u2psi': np.array([[-1, 0], [0, 0], [-1, -1], [0, -1], [-1, 1], [0, 1]]),
+                    'psi2u': np.array([[1, 0], [0, 0], [1, 1], [0, 1], [1, -1], [0, -1]]),
+                    'v2rho': np.array([[0, 0], [1, 0], [0, -1], [1, -1], [0, 1], [1, 1]]),
+                    'v2psi': np.array([[0, -1], [0, 0], [-1, -1], [-1, 0], [1, -1], [1, 0]]),
+                    }
+    translations.update({'rho2psi': -translations['psi2rho'],
+                         'v2u': -translations['u2v'],
+                         'rho2u': -translations['u2rho'],
+                         'psi2u': -translations['u2psi'],
+                         'rho2v': -translations['v2rho'],
+                         'psi2v': -translations['v2psi']
+                         })
+    if translation is None or translation not in translations.keys():
+        raise ValueError(
+            "Translation must be of: {0}".format(translations.keys()))
+
+    offsets = translations[translation]
+    new_ind = np.copy(ind)
+    test_polys = s_poly(new_ind, dest_grid.nodes)
+    not_found = np.where(~points_in_polys(points, test_polys))[0]
+    for offset in offsets:
+        # for every not found, update the cell to be checked
+        test_polys[not_found] = s_poly(
+            new_ind[not_found] + offset, dest_grid.nodes)
+        # retest the missing points. Some might be found, and will not appear
+        # in still_not_found
+        still_not_found = np.where(
+            ~points_in_polys(points[not_found], test_polys[not_found]))[0]
+        # therefore the points that were found is the intersection of the two
+        found = np.setdiff1d(not_found, still_not_found)
+        # update the indices of the ones that were found
+        not_found = still_not_found
+        new_ind[found] += offset
+        if len(not_found) == 0:
+            break
+
+    # There aren't any boundary issues thanks to numpy's indexing
+    return new_ind
+
+
+def points_in_polys(points, polys):
+    '''
+    :param points: Numpy array of Nx2 points
+    :param polys: Numpy array of N polygons of degree M represented by Mx2 points (NxMx2)
+    for each point, see if respective poly contains it. Returns array of True/False
+    '''
+    result = np.zeros((points.shape[0],), dtype=bool)
+    pointsx = points[:, 0]
+    pointsy = points[:, 1]
+    for i in range(0, polys.shape[1]):
+        v1x = polys[:, i - 1, 0]
+        v1y = polys[:, i - 1, 1]
+        v2x = polys[:, i, 0]
+        v2y = polys[:, i, 1]
+        test1 = (v2y >= pointsy) != (v1y >= pointsy)
+        test2 = pointsx < (v1x - v2x) * (pointsy - v2y) / (v1y - v2y) + v2x
+        np.logical_and(test1, test2, test1)
+        np.logical_xor(result, test1, result)
+    return result
+
+#     if ( ( (vertices[2*i+1]>point[1]) != (vertices[2*j+1]>point[1]) ) &&
+#             (point[0] < (vertices[2*j]-vertices[2*i]) * (point[1]-vertices[2*i+1]) / (vertices[2*j+1]-vertices[2*i+1]) + vertices[2*i]) )
+#             c = !c;

--- a/pysgrid/utils.py
+++ b/pysgrid/utils.py
@@ -252,7 +252,7 @@ def translate_index(points, ind, dest_grid, translation=None):
 
     offsets = translations[translation]
     new_ind = np.copy(ind)
-    test_polys = s_poly(new_ind, dest_grid.nodes)
+    test_poly = s_poly(new_ind, dest_grid.nodes)
     not_found = np.where(~points_in_polys(points, test_polys))[0]
     for offset in offsets:
         # for every not found, update the cell to be checked
@@ -274,26 +274,30 @@ def translate_index(points, ind, dest_grid, translation=None):
     return new_ind
 
 
-def points_in_polys(points, polys):
+def points_in_polys(points, polys, polyy=None):
     '''
     :param points: Numpy array of Nx2 points
     :param polys: Numpy array of N polygons of degree M represented by Mx2 points (NxMx2)
     for each point, see if respective poly contains it. Returns array of True/False
     '''
+
     result = np.zeros((points.shape[0],), dtype=bool)
     pointsx = points[:, 0]
     pointsy = points[:, 1]
+    v1x = v1y = v2x = v2y = -1
     for i in range(0, polys.shape[1]):
-        v1x = polys[:, i - 1, 0]
-        v1y = polys[:, i - 1, 1]
-        v2x = polys[:, i, 0]
-        v2y = polys[:, i, 1]
+        if polyy is not None:
+            v1x = polys[:, i - 1]
+            v1y = polyy[:, i - 1]
+            v2x = polys[:, i]
+            v2y = polyy[:, i]
+        else:
+            v1x = polys[:, i - 1, 0]
+            v1y = polys[:, i - 1, 1]
+            v2x = polys[:, i, 0]
+            v2y = polys[:, i, 1]
         test1 = (v2y >= pointsy) != (v1y >= pointsy)
         test2 = pointsx < (v1x - v2x) * (pointsy - v2y) / (v1y - v2y) + v2x
         np.logical_and(test1, test2, test1)
         np.logical_xor(result, test1, result)
     return result
-
-#     if ( ( (vertices[2*i+1]>point[1]) != (vertices[2*j+1]>point[1]) ) &&
-#             (point[0] < (vertices[2*j]-vertices[2*i]) * (point[1]-vertices[2*i+1]) / (vertices[2*j+1]-vertices[2*i+1]) + vertices[2*i]) )
-#             c = !c;

--- a/pysgrid/variables.py
+++ b/pysgrid/variables.py
@@ -49,6 +49,7 @@ class SGridVariable(object):
         self.y_axis = y_axis
         self.z_axis = z_axis
         self._data = data
+        self._loaded = False
 
     @classmethod
     def create_variable(cls, nc_var_obj, sgrid_obj):
@@ -133,11 +134,19 @@ class SGridVariable(object):
     def ndim(self):
         return self._data.ndim
 
+    @property
+    def data(self):
+        if self._loaded:
+            return self._var
+        else:
+            return self._data
+
     def __getitem__(self, item):
         """
         Transfers responsibility to the data's __getitem__
         Does not flatten any underlying data
         """
+
         if not hasattr(self, "_cache"):
             self._cache = OrderedDict()
         rv = None

--- a/pysgrid/variables.py
+++ b/pysgrid/variables.py
@@ -138,17 +138,17 @@ class SGridVariable(object):
         Transfers responsibility to the data's __getitem__
         Does not flatten any underlying data
         """
-#         if not hasattr(self, "_cache"):
-#             self._cache = OrderedDict()
-#         rv = None
-#         if str(item) in self._cache:
-#             rv = self._cache[str(item)]
-#         else:
-#             rv = self._data.__getitem__(item)
-#             self._cache[str(item)] = rv
-#             if len(self._cache) > 3:
-#                 self._cache.popitem(last=False)
-        return self._data.__getitem__(item)
+        if not hasattr(self, "_cache"):
+            self._cache = OrderedDict()
+        rv = None
+        if str(item) in self._cache:
+            rv = self._cache[str(item)]
+        else:
+            rv = self._data.__getitem__(item)
+            self._cache[str(item)] = rv
+            if len(self._cache) > 3:
+                self._cache.popitem(last=False)
+        return rv
 
     def __str__(self):
         return "UVar object: {0:s}, on the {1:s}s, and {2:d} data points\nAttributes: {3}".format(self.name, self.location, len(self.data), self.attributes)

--- a/pysgrid/variables.py
+++ b/pysgrid/variables.py
@@ -3,9 +3,8 @@ Created on Apr 15, 2015
 
 @author: ayan
 '''
-
 from __future__ import (absolute_import, division, print_function)
-
+from collections import OrderedDict
 from .read_netcdf import parse_axes, parse_vector_axis
 from .utils import determine_variable_slicing, infer_avg_axes, infer_variable_location
 
@@ -16,6 +15,7 @@ class SGridVariable(object):
     from an SGRID compliant dataset.
 
     """
+
     def __init__(self,
                  center_axis=None,
                  center_slicing=None,
@@ -31,7 +31,8 @@ class SGridVariable(object):
                  vector_axis=None,
                  x_axis=None,
                  y_axis=None,
-                 z_axis=None,):
+                 z_axis=None,
+                 data=None):
         self.center_axis = center_axis
         self.center_slicing = center_slicing
         self.coordinates = coordinates
@@ -47,6 +48,7 @@ class SGridVariable(object):
         self.x_axis = x_axis
         self.y_axis = y_axis
         self.z_axis = z_axis
+        self._data = data
 
     @classmethod
     def create_variable(cls, nc_var_obj, sgrid_obj):
@@ -110,5 +112,43 @@ class SGridVariable(object):
                         location=location,
                         standard_name=standard_name,
                         vector_axis=vector_axis,
-                        coordinates=coordinates)
+                        coordinates=coordinates,
+                        data=nc_var_obj
+                        )
         return sgrid_var
+
+    @property
+    def shape(self):
+        return self._data.shape
+
+    @property
+    def max(self):
+        return np.max(self._data)
+
+    @property
+    def min(self):
+        return np.min(self._data)
+
+    @property
+    def ndim(self):
+        return self._data.ndim
+
+    def __getitem__(self, item):
+        """
+        Transfers responsibility to the data's __getitem__
+        Does not flatten any underlying data
+        """
+#         if not hasattr(self, "_cache"):
+#             self._cache = OrderedDict()
+#         rv = None
+#         if str(item) in self._cache:
+#             rv = self._cache[str(item)]
+#         else:
+#             rv = self._data.__getitem__(item)
+#             self._cache[str(item)] = rv
+#             if len(self._cache) > 3:
+#                 self._cache.popitem(last=False)
+        return self._data.__getitem__(item)
+
+    def __str__(self):
+        return "UVar object: {0:s}, on the {1:s}s, and {2:d} data points\nAttributes: {3}".format(self.name, self.location, len(self.data), self.attributes)

--- a/pysgrid/variables.py
+++ b/pysgrid/variables.py
@@ -143,8 +143,8 @@ class SGridVariable(object):
 
     def __getitem__(self, item):
         """
-        Transfers responsibility to the data's __getitem__
-        Does not flatten any underlying data
+        Transfers responsibility to the data's __getitem__.
+        Does not flatten any underlying data.
         """
 
         if not hasattr(self, "_cache"):
@@ -160,4 +160,4 @@ class SGridVariable(object):
         return rv
 
     def __str__(self):
-        return "UVar object: {0:s}, on the {1:s}s, and {2:d} data points\nAttributes: {3}".format(self.name, self.location, len(self.data), self.attributes)
+        return "SGridVariable object: {0:s}, on the {1:s}s".format(self.standard_name, self.location)


### PR DESCRIPTION
The Cell Tree locate_faces() allows the user to pass in an array of points and receive an array of x,y indices corresponding to the cells on the nodes grid that contain these points. This function has the same signature and purpose as the locate_faces() function in pyugrid.

Some important caveats:
1. This function returns x,y indices for the psi/nodes/corners/interior grid only, the grid bounded by node_lon, node_lat.
2. Extra memory is required to store a copy of the nodes and store a faces array for use in cell_tree

Index translation allows the user to pass in an array of points, x,y indices, and a translation type, and be returned an array of x,y indices where the points are located in the destination grid. This allows you to translate the node indices provided by the Cell Tree into the correct face indices. There is also a translate_index in the pysgrid.utils that is intended to provide fully generic translations (any->any, rather than only node->any). However it is incomplete at this time.
```
lons = sgrid.center_lon
lats = sgrid.center_lat
translation = 'psi2rho' #These names are not final
face_ind = sgrid.translate_index(points, ind, lons, lats, translation)
```

The bilinear interpolation takes advantage of both of the above to provide a single function to interpolate a variable on any of the 4 grids to an array of points. 
```
var = sgrid.temp[0, 0]
temps = sgrid.interpolate_var_to_points(points, var )
```
This gives you the interpolated temperatures at those points. If you want to interpolate multiple variables at the same time on the same grid, you can ask for the interpolation alphas instead, and avoid repeat computations.
```
alphas = sgrid.interpolation_alphas(points, sgrid.center_lon, sgrid.center_lat)
temps = sgrid.interpolate_var_to_points(points, sgrid.temp[0,0], alphas)
salinity = sgrid.interpolate_var_to_points(points, sgrid.salt[0,0], alphas)
```
Be aware though that the alphas are only 'good' on the grid they are calculated for.
`u_vels = sgrid.interpolate_var_to_points(points, sgrid.u[0,0], alphas)`
will give you incorrect answers

**Near-term goals:**
~~Rename variables away from ROMS and to SGrid standard~~
Add demonstration notebook to repo
Implement optional pre-computation and storage of interpolation transform information to avoid recomputation
Implement tests
Fix and rename pysgrid.utils.translate_index. 