### PR TITLE
Re factor tests

### DIFF
--- a/pysgrid/tests/files/files.txt
+++ b/pysgrid/tests/files/files.txt
@@ -1,2 +1,0 @@
-Test netCDF files go here. These can be generated dynamically for a test or they may be placed here by a developer.
-Please do not commit binary files to git as it dramatically increases the size of the repo.

--- a/pysgrid/tests/test_interpolation.py
+++ b/pysgrid/tests/test_interpolation.py
@@ -100,9 +100,9 @@ def test_interpolation_alphas():
 
 
 def test_points_in_polys2():
-    # simple 2x2 rect
+    # Simple 2x2 rectangle.
     polygon = np.array(([0, 0], [2, 0], [2, 2], [0, 2])).reshape(1, 4, 2)
-    # points along teh boundaries
+    # Points along the boundaries.
     points = np.array([[0, 0],
                        [1, 0],
                        [2, 0],

--- a/pysgrid/tests/test_interpolation.py
+++ b/pysgrid/tests/test_interpolation.py
@@ -1,10 +1,11 @@
-'''
+"""
 Created on Feb 17, 2016
 
 @author: jay.hennen
-'''
+"""
 
 import numpy as np
+
 from ..sgrid import SGrid
 from ..utils import points_in_polys
 
@@ -100,19 +101,20 @@ def test_interpolation_alphas():
 
 
 def test_points_in_polys2():
-    # Simple 2x2 rectangle.
-    polygon = np.array(([0, 0], [2, 0], [2, 2], [0, 2])).reshape(1, 4, 2)
-    # Points along the boundaries.
-    points = np.array([[0, 0],
-                       [1, 0],
-                       [2, 0],
-                       [0, 1],
-                       [0, 2],
-                       [1, 2],
-                       [2, 2],
-                       [2, 1]])
-    pinp = np.array([points_in_polys(point.reshape(1, 2), polygon)
-                     for point in points]).reshape(-1)
-    answer = sgrid.locate_faces(points + 1, 'node') == [0, 0]
+    rectangle = np.array(([0, 0],
+                          [2, 0],
+                          [2, 2],
+                          [0, 2])).reshape(1, 4, 2)
+    boundaries = np.array([[0, 0],
+                           [1, 0],
+                           [2, 0],
+                           [0, 1],
+                           [0, 2],
+                           [1, 2],
+                           [2, 2],
+                           [2, 1]])
+    pinp = np.array([points_in_polys(point.reshape(1, 2), rectangle)
+                     for point in boundaries]).reshape(-1)
+    answer = sgrid.locate_faces(boundaries + 1, 'node') == [0, 0]
     answer = np.logical_and(answer[:, 0], answer[:, 1])
     assert (answer == pinp).all()

--- a/pysgrid/tests/test_processing_2d.py
+++ b/pysgrid/tests/test_processing_2d.py
@@ -1,69 +1,72 @@
-'''
+"""
 Created on Apr 3, 2015
 
 @author: ayan
-'''
+
+"""
 
 from __future__ import (absolute_import, division, print_function)
 
-import unittest
+import pytest
 import numpy as np
 
 from ..processing_2d import avg_to_cell_center, rotate_vectors, vector_sum
 
 
-class TestVectorSum(unittest.TestCase):
-    def setUp(self):
-        self.x_vector = np.array([3, 5, 9, 11])
-        self.y_vector = np.array([4, 12, 40, 60])
-
-    def test_vector_sum(self):
-        sum_result = vector_sum(self.x_vector, self.y_vector)
-        expected = np.array([5, 13, 41, 61])
-        np.testing.assert_almost_equal(sum_result, expected)
+def test_vector_sum():
+    x_vector = np.array([3, 5, 9, 11])
+    y_vector = np.array([4, 12, 40, 60])
+    sum_result = vector_sum(x_vector, y_vector)
+    expected = np.array([5, 13, 41, 61])
+    np.testing.assert_almost_equal(sum_result, expected)
 
 
-class TestRotateVectors(unittest.TestCase):
-    def setUp(self):
-        self.x_vector = np.array([3, 5, 9, 11])
-        self.y_vector = np.array([4, 12, 40, 60])
-        self.angles_simple = np.array([0, np.pi / 2, 0, np.pi / 2])
-        self.angles_complex = np.array([np.pi / 6, np.pi / 5,
-                                        np.pi / 4, np.pi / 3])
-
-    def test_vector_rotation_simple(self):
-        rotated_x, rotated_y = rotate_vectors(self.x_vector,
-                                              self.y_vector,
-                                              self.angles_simple)
-        expected_x = np.array([3, -12, 9, -60])
-        expected_y = np.array([4, 5, 40, 11])
-        np.testing.assert_almost_equal(rotated_x, expected_x, decimal=3)
-        np.testing.assert_almost_equal(rotated_y, expected_y, decimal=3)
-
-    def test_vector_rotation_complex(self):
-        rotated_x, rotated_y = rotate_vectors(self.x_vector,
-                                              self.y_vector,
-                                              self.angles_complex)
-        expected_x = np.array([0.5981, -3.0083, -21.9203, -46.4615])
-        expected_y = np.array([4.9641, 12.6471, 34.6482, 39.5263])
-        np.testing.assert_almost_equal(rotated_x, expected_x, decimal=3)
-        np.testing.assert_almost_equal(rotated_y, expected_y, decimal=3)
+@pytest.fixture
+def rotate_vectors_data():
+    x = np.array([3, 5, 9, 11])
+    y = np.array([4, 12, 40, 60])
+    angles_simple = np.array([0, np.pi / 2, 0, np.pi / 2])
+    angles_complex = np.array([np.pi / 6, np.pi / 5,
+                               np.pi / 4, np.pi / 3])
+    return x, y, angles_simple, angles_complex
 
 
-class TestAvgToCellCenter(unittest.TestCase):
-    def setUp(self):
-        self.data = np.array([[4, 5, 9, 10], [8, 39, 41, 20], [5, 29, 18, 71]])
-        self.avg_dim_0 = 0
-        self.avg_dim_1 = 1
+def test_vector_rotation_simple():
+    x, y, angles_simple, angles_complex = rotate_vectors_data()
+    rotated_x, rotated_y = rotate_vectors(x, y, angles_simple)
 
-    def test_no_transpose(self):
-        avg_result = avg_to_cell_center(self.data, self.avg_dim_1)
-        expected = np.array([[4.5, 7, 9.5],
-                             [23.5, 40, 30.5],
-                             [17, 23.5, 44.5]])
-        np.testing.assert_almost_equal(avg_result, expected, decimal=3)
+    expected_x = np.array([3, -12, 9, -60])
+    expected_y = np.array([4, 5, 40, 11])
 
-    def test_with_transpose(self):
-        avg_result = avg_to_cell_center(self.data, self.avg_dim_0)
-        expected = np.array([[6, 22, 25, 15], [6.5, 34, 29.5, 45.5]])
-        np.testing.assert_almost_equal(avg_result, expected, decimal=3)
+    np.testing.assert_almost_equal(rotated_x, expected_x, decimal=3)
+    np.testing.assert_almost_equal(rotated_y, expected_y, decimal=3)
+
+
+def test_vector_rotation_complex():
+    x, y, angles_simple, angles_complex = rotate_vectors_data()
+    rotated_x, rotated_y = rotate_vectors(x, y, angles_complex)
+    expected_x = np.array([0.5981, -3.0083, -21.9203, -46.4615])
+    expected_y = np.array([4.9641, 12.6471, 34.6482, 39.5263])
+    np.testing.assert_almost_equal(rotated_x, expected_x, decimal=3)
+    np.testing.assert_almost_equal(rotated_y, expected_y, decimal=3)
+
+
+@pytest.fixture
+def avg_center_data():
+    return np.array([[4, 5, 9, 10], [8, 39, 41, 20], [5, 29, 18, 71]])
+
+
+def test_no_transpose():
+    data = avg_center_data()
+    avg_result = avg_to_cell_center(data, 1)
+    expected = np.array([[4.5, 7, 9.5],
+                         [23.5, 40, 30.5],
+                         [17, 23.5, 44.5]])
+    np.testing.assert_almost_equal(avg_result, expected, decimal=3)
+
+
+def test_with_transpose():
+    data = avg_center_data()
+    avg_result = avg_to_cell_center(data, 0)
+    expected = np.array([[6, 22, 25, 15], [6.5, 34, 29.5, 45.5]])
+    np.testing.assert_almost_equal(avg_result, expected, decimal=3)

--- a/pysgrid/tests/test_read_netcdf.py
+++ b/pysgrid/tests/test_read_netcdf.py
@@ -8,7 +8,7 @@ Created on Apr 7, 2015
 from __future__ import absolute_import, division, print_function
 
 from ..read_netcdf import NetCDFDataset, find_grid_topology_var
-from .write_nc_test_files import roms_sgrid, wrf_sgrid_2d
+from .write_nc_test_files import roms_sgrid, wrf_sgrid
 
 
 """
@@ -69,21 +69,21 @@ Test NetCDF Dataset Without Nodes.
 """
 
 
-def test_node_coordinates(wrf_sgrid_2d):
-    nc_ds = NetCDFDataset(wrf_sgrid_2d)
+def test_node_coordinates(wrf_sgrid):
+    nc_ds = NetCDFDataset(wrf_sgrid)
     node_coordinates = nc_ds.find_node_coordinates('west_east_stag south_north_stag')  # noqa
     assert node_coordinates is None
 
 
-def test_find_variable_by_attr(wrf_sgrid_2d):
-    nc_ds = NetCDFDataset(wrf_sgrid_2d)
+def test_find_variable_by_attr(wrf_sgrid):
+    nc_ds = NetCDFDataset(wrf_sgrid)
     result = nc_ds.find_variables_by_attr(cf_role='grid_topology',
                                           topology_dimension=2)
     expected = ['grid']
     assert result == expected
 
 
-def test_find_variable_by_nonexistant_attr(wrf_sgrid_2d):
-    nc_ds = NetCDFDataset(wrf_sgrid_2d)
+def test_find_variable_by_nonexistant_attr(wrf_sgrid):
+    nc_ds = NetCDFDataset(wrf_sgrid)
     result = nc_ds.find_variables_by_attr(bird='tufted titmouse')
     assert result == []

--- a/pysgrid/tests/test_read_netcdf.py
+++ b/pysgrid/tests/test_read_netcdf.py
@@ -1,107 +1,22 @@
-'''
+"""
 Created on Apr 7, 2015
 
 @author: ayan
-'''
 
-from __future__ import (absolute_import, division, print_function)
+"""
 
-import unittest
+from __future__ import absolute_import, division, print_function
 
-from ..read_netcdf import (NetCDFDataset, parse_axes, parse_padding,
-                           parse_vector_axis, find_grid_topology_var)
+from ..read_netcdf import NetCDFDataset, find_grid_topology_var
 from .write_nc_test_files import roms_sgrid, wrf_sgrid_2d
 
 
-class TestParseAxes(unittest.TestCase):
-    def setUp(self):
-        self.xy = 'X: xi_psi Y: eta_psi'
-        self.xyz = 'X: NMAX Y: MMAXZ Z: KMAX'
+"""
+Test NetCDF Dataset With Nodes.
 
-    def test_xyz_axis_parse(self):
-        result = parse_axes(self.xyz)
-        expected = ('NMAX', 'MMAXZ', 'KMAX')
-        self.assertEqual(result, expected)
-
-    def test_xy_axis_parse(self):
-        result = parse_axes(self.xy)
-        expected = ('xi_psi', 'eta_psi', None)
-        self.assertEqual(result, expected)
+"""
 
 
-class TestParsePadding(unittest.TestCase):
-    def setUp(self):
-        self.grid_topology = 'some_grid'
-        self.with_two_padding = 'xi_rho: xi_psi (padding: both) eta_rho: eta_psi (padding: low)'  # noqa
-        self.with_one_padding = 'xi_v: xi_psi (padding: high) eta_v: eta_psi'
-        self.with_no_padding = 'MMAXZ: MMAX NMAXZ: NMAX'
-
-    def test_mesh_name(self):
-        result = parse_padding(self.with_one_padding, self.grid_topology)
-        mesh_topology = result[0].mesh_topology_var
-        expected = 'some_grid'
-        self.assertEqual(mesh_topology, expected)
-
-    def test_two_padding_types(self):
-        result = parse_padding(self.with_two_padding, self.grid_topology)
-        expected_len = 2
-        padding_datum_0 = result[0]
-        padding_type = padding_datum_0.padding
-        sub_dim = padding_datum_0.node_dim
-        dim = padding_datum_0.face_dim
-        expected_sub_dim = 'xi_psi'
-        expected_padding_type = 'both'
-        expected_dim = 'xi_rho'
-        self.assertEqual(len(result), expected_len)
-        self.assertEqual(padding_type, expected_padding_type)
-        self.assertEqual(sub_dim, expected_sub_dim)
-        self.assertEqual(dim, expected_dim)
-
-    def test_one_padding_type(self):
-        result = parse_padding(self.with_one_padding, self.grid_topology)
-        expected_len = 1
-        padding_datum_0 = result[0]
-        padding_type = padding_datum_0.padding
-        sub_dim = padding_datum_0.node_dim
-        dim = padding_datum_0.face_dim
-        expected_padding_type = 'high'
-        expected_sub_dim = 'xi_psi'
-        expected_dim = 'xi_v'
-        self.assertEqual(len(result), expected_len)
-        self.assertEqual(padding_type, expected_padding_type)
-        self.assertEqual(sub_dim, expected_sub_dim)
-        self.assertEqual(dim, expected_dim)
-
-    def test_no_padding(self):
-        self.assertRaises(ValueError,
-                          parse_padding,
-                          padding_str=self.with_no_padding,
-                          mesh_topology_var=self.grid_topology
-                          )
-
-
-class TestParseVectorAxis(unittest.TestCase):
-    def setUp(self):
-        self.standard_name_1 = 'sea_water_y_velocity'
-        self.standard_name_2 = 'atmosphere_optical_thickness_due_to_cloud'
-        self.standard_name_3 = 'ocean_heat_x_transport_due_to_diffusion'
-
-    def test_std_name_with_velocity_direction(self):
-        direction = parse_vector_axis(self.standard_name_1)
-        expected_direction = 'Y'
-        self.assertEqual(direction, expected_direction)
-
-    def test_std_name_without_direction(self):
-        direction = parse_vector_axis(self.standard_name_2)
-        self.assertIsNone(direction)
-
-    def test_std_name_with_transport_direction(self):
-        direction = parse_vector_axis(self.standard_name_3)
-        expected_direction = 'X'
-        self.assertEqual(direction, expected_direction)
-
-
-# TestNetCDFDatasetWithNodes.
 def test_finding_node_variables(roms_sgrid):
     nc_ds = NetCDFDataset(roms_sgrid)
     result = nc_ds.find_node_coordinates('xi_psi eta_psi')
@@ -148,7 +63,12 @@ def test_sgrid_compliant_check(roms_sgrid):
     assert result
 
 
-# TestNetCDFDatasetWithoutNodes
+"""
+Test NetCDF Dataset Without Nodes.
+
+"""
+
+
 def test_node_coordinates(wrf_sgrid_2d):
     nc_ds = NetCDFDataset(wrf_sgrid_2d)
     node_coordinates = nc_ds.find_node_coordinates('west_east_stag south_north_stag')  # noqa

--- a/pysgrid/tests/test_sgrid_deltares.py
+++ b/pysgrid/tests/test_sgrid_deltares.py
@@ -28,38 +28,38 @@ A file is representing a delft3d dataset is used for this test.
 
 
 @pytest.fixture
-def sgrid_deltares(deltares_sgrid_no_optional_attr):
+def sgrid(deltares_sgrid_no_optional_attr):
     return load_grid(deltares_sgrid_no_optional_attr)
 
 
-def test_face_coordinate_inference(sgrid_deltares):
-    face_coordinates = sgrid_deltares.face_coordinates
+def test_face_coordinate_inference(sgrid):
+    face_coordinates = sgrid.face_coordinates
     expected_face_coordinates = (u'XZ', u'YZ')
     assert face_coordinates == expected_face_coordinates
 
 
-def test_center_lon_deltares_no_coord(sgrid_deltares):
-    center_lon = sgrid_deltares.center_lon
+def test_center_lon_deltares_no_coord(sgrid):
+    center_lon = sgrid.center_lon
     assert center_lon.shape == (4, 4)
 
 
-def test_center_lat_deltares_no_coord(sgrid_deltares):
-    center_lat = sgrid_deltares.center_lat
+def test_center_lat_deltares_no_coord(sgrid):
+    center_lat = sgrid.center_lat
     assert center_lat.shape == (4, 4)
 
 
-def test_node_lon(sgrid_deltares):
-    node_lon = sgrid_deltares.node_lon
+def test_node_lon(sgrid):
+    node_lon = sgrid.node_lon
     assert node_lon.shape == (4, 4)
 
 
-def test_node_lat(sgrid_deltares):
-    node_lat = sgrid_deltares.node_lat
+def test_node_lat(sgrid):
+    node_lat = sgrid.node_lat
     assert node_lat.shape == (4, 4)
 
 
-def test_grid_angles(sgrid_deltares):
-    angles = sgrid_deltares.angles
+def test_grid_angles(sgrid):
+    angles = sgrid.angles
     angles_shape = (4, 4)
     assert angles.shape == angles_shape
 
@@ -71,33 +71,33 @@ Test SGrid Delft3d Dataset.
 
 
 @pytest.fixture
-def sgrid_obj_deltares(deltares_sgrid):
+def sgrid_obj(deltares_sgrid):
     return load_grid(deltares_sgrid)
 
 
-def test_center_lon_deltares(sgrid_obj_deltares):
-    center_lon = sgrid_obj_deltares.center_lon
+def test_center_lon_deltares(sgrid_obj):
+    center_lon = sgrid_obj.center_lon
     assert center_lon.shape == (4, 4)
 
 
-def test_center_lat_deltares(sgrid_obj_deltares):
-    center_lat = sgrid_obj_deltares.center_lat
+def test_center_lat_deltares(sgrid_obj):
+    center_lat = sgrid_obj.center_lat
     assert center_lat.shape == (4, 4)
 
 
-def test_topology_dimension_deltares(sgrid_obj_deltares):
-    topology_dim = sgrid_obj_deltares.topology_dimension
+def test_topology_dimension_deltares(sgrid_obj):
+    topology_dim = sgrid_obj.topology_dimension
     expected_dim = 2
     assert topology_dim == expected_dim
 
 
-def test_variable_slice(sgrid_obj_deltares):
-    u_center_slices = sgrid_obj_deltares.U1.center_slicing
-    v_center_slices = sgrid_obj_deltares.V1.center_slicing
+def test_variable_slice(sgrid_obj):
+    u_center_slices = sgrid_obj.U1.center_slicing
+    v_center_slices = sgrid_obj.V1.center_slicing
     u_center_expected = (np.s_[:], np.s_[:], np.s_[:], np.s_[1:])
     v_center_expected = (np.s_[:], np.s_[:], np.s_[1:], np.s_[:])
-    xz_center_slices = sgrid_obj_deltares.XZ.center_slicing
-    xcor_center_slices = sgrid_obj_deltares.XCOR.center_slicing
+    xz_center_slices = sgrid_obj.XZ.center_slicing
+    xcor_center_slices = sgrid_obj.XCOR.center_slicing
     xz_center_expected = (np.s_[1:], np.s_[1:])
     xcor_center_expected = (np.s_[:], np.s_[:])
     assert u_center_slices == u_center_expected
@@ -106,24 +106,24 @@ def test_variable_slice(sgrid_obj_deltares):
     assert xcor_center_slices == xcor_center_expected
 
 
-def test_averaging_axes(sgrid_obj_deltares):
-    u1c_axis = sgrid_obj_deltares.U1.center_axis
+def test_averaging_axes(sgrid_obj):
+    u1c_axis = sgrid_obj.U1.center_axis
     u1c_expected = 0
-    v1n_axis = sgrid_obj_deltares.V1.node_axis
+    v1n_axis = sgrid_obj.V1.node_axis
     v1n_expected = 0
-    latitude_c_axis = sgrid_obj_deltares.latitude.center_axis
-    latitude_n_axis = sgrid_obj_deltares.latitude.node_axis
+    latitude_c_axis = sgrid_obj.latitude.center_axis
+    latitude_n_axis = sgrid_obj.latitude.node_axis
     assert u1c_axis == u1c_expected
     assert v1n_axis == v1n_expected
     assert latitude_c_axis is None
     assert latitude_n_axis is None
 
 
-def test_grid_optional_attrs(sgrid_obj_deltares):
-    face_coordinates = sgrid_obj_deltares.face_coordinates
-    node_coordinates = sgrid_obj_deltares.node_coordinates
-    edge1_coordinates = sgrid_obj_deltares.edge1_coordinates
-    edge2_coordinates = sgrid_obj_deltares.edge2_coordinates
+def test_grid_optional_attrs(sgrid_obj):
+    face_coordinates = sgrid_obj.face_coordinates
+    node_coordinates = sgrid_obj.node_coordinates
+    edge1_coordinates = sgrid_obj.edge1_coordinates
+    edge2_coordinates = sgrid_obj.edge2_coordinates
     fc_expected = ('XZ', 'YZ')
     nc_expected = ('XCOR', 'YCOR')
     assert face_coordinates == fc_expected
@@ -132,41 +132,41 @@ def test_grid_optional_attrs(sgrid_obj_deltares):
     assert edge2_coordinates is None
 
 
-def test_grid_variables_deltares(sgrid_obj_deltares):
-    grid_variables = sgrid_obj_deltares.grid_variables
+def test_grid_variables_deltares(sgrid_obj):
+    grid_variables = sgrid_obj.grid_variables
     expected_grid_variables = [u'U1', u'V1', u'FAKE_U1', u'W', u'FAKE_W']
     assert set(grid_variables) == set(expected_grid_variables)
 
 
-def test_angles(sgrid_obj_deltares):
-    angles = sgrid_obj_deltares.angles
+def test_angles(sgrid_obj):
+    angles = sgrid_obj.angles
     expected_shape = (4, 4)
     assert angles.shape == expected_shape
 
 
-def test_no_3d_attributes(sgrid_obj_deltares):
-    assert not hasattr(sgrid_obj_deltares, 'volume_padding')
-    assert not hasattr(sgrid_obj_deltares, 'volume_dimensions')
-    assert not hasattr(sgrid_obj_deltares, 'volume_coordinates')
-    assert not hasattr(sgrid_obj_deltares, 'face1_padding')
-    assert not hasattr(sgrid_obj_deltares, 'face1_coordinates')
-    assert not hasattr(sgrid_obj_deltares, 'face1_dimensions')
-    assert not hasattr(sgrid_obj_deltares, 'face2_padding')
-    assert not hasattr(sgrid_obj_deltares, 'face2_coordinates')
-    assert not hasattr(sgrid_obj_deltares, 'face2_dimensions')
-    assert not hasattr(sgrid_obj_deltares, 'face3_padding')
-    assert not hasattr(sgrid_obj_deltares, 'face3_coordinates')
-    assert not hasattr(sgrid_obj_deltares, 'edge3_padding')
-    assert not hasattr(sgrid_obj_deltares, 'edge3_coordinates')
-    assert not hasattr(sgrid_obj_deltares, 'edge3_dimensions')
+def test_no_3d_attributes(sgrid_obj):
+    assert not hasattr(sgrid_obj, 'volume_padding')
+    assert not hasattr(sgrid_obj, 'volume_dimensions')
+    assert not hasattr(sgrid_obj, 'volume_coordinates')
+    assert not hasattr(sgrid_obj, 'face1_padding')
+    assert not hasattr(sgrid_obj, 'face1_coordinates')
+    assert not hasattr(sgrid_obj, 'face1_dimensions')
+    assert not hasattr(sgrid_obj, 'face2_padding')
+    assert not hasattr(sgrid_obj, 'face2_coordinates')
+    assert not hasattr(sgrid_obj, 'face2_dimensions')
+    assert not hasattr(sgrid_obj, 'face3_padding')
+    assert not hasattr(sgrid_obj, 'face3_coordinates')
+    assert not hasattr(sgrid_obj, 'edge3_padding')
+    assert not hasattr(sgrid_obj, 'edge3_coordinates')
+    assert not hasattr(sgrid_obj, 'edge3_dimensions')
 
 
-def test_2d_attributes(sgrid_obj_deltares):
-    assert hasattr(sgrid_obj_deltares, 'face_padding')
-    assert hasattr(sgrid_obj_deltares, 'face_coordinates')
-    assert hasattr(sgrid_obj_deltares, 'face_dimensions')
-    assert hasattr(sgrid_obj_deltares, 'vertical_padding')
-    assert hasattr(sgrid_obj_deltares, 'vertical_dimensions')
+def test_2d_attributes(sgrid_obj):
+    assert hasattr(sgrid_obj, 'face_padding')
+    assert hasattr(sgrid_obj, 'face_coordinates')
+    assert hasattr(sgrid_obj, 'face_dimensions')
+    assert hasattr(sgrid_obj, 'vertical_padding')
+    assert hasattr(sgrid_obj, 'vertical_dimensions')
 
 
 """
@@ -188,17 +188,17 @@ def test_round_trip(deltares_sgrid, tmpdir):
 
 
 @pytest.fixture
-def sgrid_deltares_sgrid(deltares_sgrid):
+def sgrid_no_node(deltares_sgrid):
     return load_grid(deltares_sgrid)
 
 
-def test_save_as_netcdf(sgrid_deltares_sgrid):
+def test_save_as_netcdf(sgrid_no_node):
     """
     Test that the attributes in the
     saved netCDF file are as expected.
 
     """
-    target_dims = sgrid_deltares_sgrid.dimensions
+    target_dims = sgrid_no_node.dimensions
     expected_target_dims = [(u'MMAXZ', 4),
                             (u'NMAXZ', 4),
                             (u'MMAX', 4),
@@ -207,7 +207,7 @@ def test_save_as_netcdf(sgrid_deltares_sgrid):
                             (u'KMAX1', 3),
                             (u'time', 2)
                             ]
-    target_vars = sgrid_deltares_sgrid.variables
+    target_vars = sgrid_no_node.variables
     expected_target_vars = [u'XZ',
                             u'YZ',
                             u'XCOR',
@@ -224,15 +224,15 @@ def test_save_as_netcdf(sgrid_deltares_sgrid):
                             u'grid_latitude',
                             u'grid_longitude'
                             ]
-    target_grid_vars = sgrid_deltares_sgrid.grid_variables
+    target_grid_vars = sgrid_no_node.grid_variables
     expected_target_grid_vars = [u'U1',
                                  u'FAKE_U1',
                                  u'V1',
                                  u'W',
                                  u'FAKE_W']
-    target_face_coordinates = sgrid_deltares_sgrid.face_coordinates
+    target_face_coordinates = sgrid_no_node.face_coordinates
     expected_target_face_coordinates = (u'XZ', u'YZ')
-    assert isinstance(sgrid_deltares_sgrid, SGrid)
+    assert isinstance(sgrid_no_node, SGrid)
     assert len(target_dims) == len(expected_target_dims)
     assert set(target_dims) == set(expected_target_dims)
     assert len(target_vars) == len(expected_target_vars)
@@ -242,19 +242,19 @@ def test_save_as_netcdf(sgrid_deltares_sgrid):
     assert target_face_coordinates == expected_target_face_coordinates
 
 
-def test_saved_sgrid_attributes(sgrid_deltares_sgrid):
+def test_saved_sgrid_attributes(sgrid_no_node):
     """
     Test that calculated/inferred attributes
     are as expected from the saved filed.
 
     """
-    u1_var = sgrid_deltares_sgrid.U1
+    u1_var = sgrid_no_node.U1
     u1_var_center_avg_axis = u1_var.center_axis
     expected_u1_center_axis = 0
     u1_vector_axis = u1_var.vector_axis
     expected_u1_vector_axis = 'X'
-    original_angles = sgrid_deltares_sgrid.angles
-    saved_angles = sgrid_deltares_sgrid.angles
+    original_angles = sgrid_no_node.angles
+    saved_angles = sgrid_no_node.angles
     assert u1_var_center_avg_axis == expected_u1_center_axis
     assert u1_vector_axis == expected_u1_vector_axis
     np.testing.assert_almost_equal(original_angles, saved_angles, decimal=3)  # noqa

--- a/pysgrid/tests/test_sgrid_non_compliant.py
+++ b/pysgrid/tests/test_sgrid_non_compliant.py
@@ -1,0 +1,19 @@
+"""
+Created on Apr 7, 2015
+
+@author: ayan
+
+"""
+
+from __future__ import (absolute_import, division, print_function)
+
+import pytest
+
+from ..sgrid import load_grid
+
+from .write_nc_test_files import non_compliant_sgrid
+
+
+def test_exception_raised(non_compliant_sgrid):
+    with pytest.raises(ValueError):
+        load_grid(non_compliant_sgrid)

--- a/pysgrid/tests/test_sgrid_parsing.py
+++ b/pysgrid/tests/test_sgrid_parsing.py
@@ -1,0 +1,104 @@
+"""
+Created on Apr 7, 2015
+
+@author: ayan
+
+"""
+
+from __future__ import (absolute_import, division, print_function)
+
+import pytest
+
+from ..read_netcdf import (parse_axes, parse_padding, parse_vector_axis)
+
+
+def test_xyz_axis_parse():
+    xyz = 'X: NMAX Y: MMAXZ Z: KMAX'
+    result = parse_axes(xyz)
+    expected = ('NMAX', 'MMAXZ', 'KMAX')
+    assert result == expected
+
+
+def test_xy_axis_parse():
+    xy = 'X: xi_psi Y: eta_psi'
+    result = parse_axes(xy)
+    expected = ('xi_psi', 'eta_psi', None)
+    assert result == expected
+
+
+@pytest.fixture
+def parse_pad():
+    grid_topology = 'some_grid'
+    pad_1 = 'xi_v: xi_psi (padding: high) eta_v: eta_psi'
+    pad_2 = 'xi_rho: xi_psi (padding: both) eta_rho: eta_psi (padding: low)'
+    pad_no = 'MMAXZ: MMAX NMAXZ: NMAX'
+    return grid_topology, pad_1, pad_2, pad_no
+
+
+def test_mesh_name():
+    grid_topology, pad_1, pad_2, pad_no = parse_pad()
+    result = parse_padding(pad_1, grid_topology)
+    mesh_topology = result[0].mesh_topology_var
+    expected = 'some_grid'
+    assert mesh_topology == expected
+
+
+def test_two_padding_types():
+    grid_topology, pad_1, pad_2, pad_no = parse_pad()
+    result = parse_padding(pad_2, grid_topology)
+    expected_len = 2
+    padding_datum_0 = result[0]
+    padding_type = padding_datum_0.padding
+    sub_dim = padding_datum_0.node_dim
+    dim = padding_datum_0.face_dim
+    expected_sub_dim = 'xi_psi'
+    expected_padding_type = 'both'
+    expected_dim = 'xi_rho'
+    assert len(result) == expected_len
+    assert padding_type == expected_padding_type
+    assert sub_dim == expected_sub_dim
+    assert dim == expected_dim
+
+
+def test_one_padding_type():
+    grid_topology, pad_1, pad_2, pad_no = parse_pad()
+    result = parse_padding(pad_1, grid_topology)
+    expected_len = 1
+    padding_datum_0 = result[0]
+    padding_type = padding_datum_0.padding
+    sub_dim = padding_datum_0.node_dim
+    dim = padding_datum_0.face_dim
+    expected_padding_type = 'high'
+    expected_sub_dim = 'xi_psi'
+    expected_dim = 'xi_v'
+    assert len(result) == expected_len
+    assert padding_type == expected_padding_type
+    assert sub_dim == expected_sub_dim
+    assert dim == expected_dim
+
+
+def test_no_padding():
+    grid_topology, pad_1, pad_2, pad_no = parse_pad()
+    with pytest.raises(ValueError):
+        parse_padding(padding_str=pad_no,
+                      mesh_topology_var=grid_topology)
+
+
+def test_std_name_with_velocity_direction():
+    standard_name_1 = 'sea_water_y_velocity'
+    direction = parse_vector_axis(standard_name_1)
+    expected_direction = 'Y'
+    assert direction == expected_direction
+
+
+def test_std_name_without_direction():
+    standard_name_2 = 'atmosphere_optical_thickness_due_to_cloud'
+    direction = parse_vector_axis(standard_name_2)
+    assert direction is None
+
+
+def test_std_name_with_transport_direction():
+    standard_name_3 = 'ocean_heat_x_transport_due_to_diffusion'
+    direction = parse_vector_axis(standard_name_3)
+    expected_direction = 'X'
+    assert direction == expected_direction

--- a/pysgrid/tests/test_sgrid_roms.py
+++ b/pysgrid/tests/test_sgrid_roms.py
@@ -26,22 +26,22 @@ def test_load_from_dataset(roms_sgrid):
 
 
 @pytest.fixture
-def sgrid_roms_sgrid(roms_sgrid):
+def sgrid(roms_sgrid):
     return load_grid(roms_sgrid)
 
 
-def test_center_lon(sgrid_roms_sgrid):
-    center_lon = sgrid_roms_sgrid.center_lon
+def test_center_lon(sgrid):
+    center_lon = sgrid.center_lon
     assert center_lon.shape == (4, 4)
 
 
-def test_center_lat(sgrid_roms_sgrid):
-    center_lat = sgrid_roms_sgrid.center_lat
+def test_center_lat(sgrid):
+    center_lat = sgrid.center_lat
     assert center_lat.shape == (4, 4)
 
 
-def test_variables(sgrid_roms_sgrid):
-    dataset_vars = sgrid_roms_sgrid.variables
+def test_variables(sgrid):
+    dataset_vars = sgrid.variables
     expected_vars = [u's_rho',
                      u's_w',
                      u'time',
@@ -71,15 +71,15 @@ def test_variables(sgrid_roms_sgrid):
     assert dataset_vars == expected_vars
 
 
-def test_grid_variables(sgrid_roms_sgrid):
-    dataset_grid_variables = sgrid_roms_sgrid.grid_variables
+def test_grid_variables(sgrid):
+    dataset_grid_variables = sgrid.grid_variables
     expected_grid_variables = [u'u', u'v', u'fake_u', u'salt']
     assert len(dataset_grid_variables) == len(expected_grid_variables)
     assert set(dataset_grid_variables) == set(expected_grid_variables)
 
 
-def test_non_grid_variables(sgrid_roms_sgrid):
-    dataset_non_grid_variables = sgrid_roms_sgrid.non_grid_variables
+def test_non_grid_variables(sgrid):
+    dataset_non_grid_variables = sgrid.non_grid_variables
     expected_non_grid_variables = [u's_rho',
                                    u's_w',
                                    u'time',
@@ -105,33 +105,33 @@ def test_non_grid_variables(sgrid_roms_sgrid):
     assert set(dataset_non_grid_variables) == set(expected_non_grid_variables)
 
 
-def test_variable_slicing(sgrid_roms_sgrid):
-    u_center_slices = sgrid_roms_sgrid.u.center_slicing
-    v_center_slices = sgrid_roms_sgrid.v.center_slicing
+def test_variable_slicing(sgrid):
+    u_center_slices = sgrid.u.center_slicing
+    v_center_slices = sgrid.v.center_slicing
     u_center_expected = (np.s_[:], np.s_[:], np.s_[1:-1], np.s_[:])
     v_center_expected = (np.s_[:], np.s_[:], np.s_[:], np.s_[1:-1])
     assert u_center_slices == u_center_expected
     assert v_center_slices == v_center_expected
 
 
-def test_grid_variable_average_axes(sgrid_roms_sgrid):
-    uc_axis = sgrid_roms_sgrid.u.center_axis
+def test_grid_variable_average_axes(sgrid):
+    uc_axis = sgrid.u.center_axis
     uc_axis_expected = 1
-    un_axis = sgrid_roms_sgrid.u.node_axis
+    un_axis = sgrid.u.node_axis
     un_axis_expected = 0
-    lon_rho_c_axis = sgrid_roms_sgrid.lon_rho.center_axis
-    lon_rho_n_axis = sgrid_roms_sgrid.lon_rho.node_axis
+    lon_rho_c_axis = sgrid.lon_rho.center_axis
+    lon_rho_n_axis = sgrid.lon_rho.node_axis
     assert uc_axis == uc_axis_expected
     assert un_axis == un_axis_expected
     assert lon_rho_c_axis is None
     assert lon_rho_n_axis is None
 
 
-def test_optional_grid_attrs(sgrid_roms_sgrid):
-    face_coordinates = sgrid_roms_sgrid.face_coordinates
-    node_coordinates = sgrid_roms_sgrid.node_coordinates
-    edge1_coordinates = sgrid_roms_sgrid.edge1_coordinates
-    edge2_coordinates = sgrid_roms_sgrid.edge2_coordinates
+def test_optional_grid_attrs(sgrid):
+    face_coordinates = sgrid.face_coordinates
+    node_coordinates = sgrid.node_coordinates
+    edge1_coordinates = sgrid.edge1_coordinates
+    edge2_coordinates = sgrid.edge2_coordinates
     fc_expected = ('lon_rho', 'lat_rho')
     nc_expected = ('lon_psi', 'lat_psi')
     e1c_expected = ('lon_u', 'lat_u')
@@ -142,12 +142,12 @@ def test_optional_grid_attrs(sgrid_roms_sgrid):
     assert edge2_coordinates == e2c_expected
 
 
-def test_round_trip(sgrid_roms_sgrid, tmpdir):
+def test_round_trip(sgrid, tmpdir):
     """
     TODO: add more "round-trip" tests.
 
     """
     fname = tmpdir.mkdir('files').join('deltares_roundtrip.nc')
-    sgrid_roms_sgrid.save_as_netcdf(fname)
+    sgrid.save_as_netcdf(fname)
     result = load_grid(fname)
     assert isinstance(result, SGrid)

--- a/pysgrid/tests/test_sgrid_roms.py
+++ b/pysgrid/tests/test_sgrid_roms.py
@@ -20,12 +20,6 @@ Test SGrid ROMS.
 """
 
 
-def test_load_from_file(roms_sgrid):
-    fname = 'tmp_sgrid_roms.nc'  # FIXME: name handling in the fixture.
-    sg_obj = load_grid(fname)
-    assert isinstance(sg_obj, SGrid)
-
-
 def test_load_from_dataset(roms_sgrid):
     sg_obj = load_grid(roms_sgrid)
     assert isinstance(sg_obj, SGrid)

--- a/pysgrid/tests/test_sgrid_roms.py
+++ b/pysgrid/tests/test_sgrid_roms.py
@@ -1,0 +1,159 @@
+"""
+Created on Apr 7, 2015
+
+@author: ayan
+
+"""
+
+from __future__ import (absolute_import, division, print_function)
+
+import pytest
+import numpy as np
+
+from ..sgrid import SGrid, load_grid
+from .write_nc_test_files import roms_sgrid
+
+
+"""
+Test SGrid ROMS.
+
+"""
+
+
+def test_load_from_file(roms_sgrid):
+    fname = 'tmp_sgrid_roms.nc'  # FIXME: name handling in the fixture.
+    sg_obj = load_grid(fname)
+    assert isinstance(sg_obj, SGrid)
+
+
+def test_load_from_dataset(roms_sgrid):
+    sg_obj = load_grid(roms_sgrid)
+    assert isinstance(sg_obj, SGrid)
+
+
+@pytest.fixture
+def sgrid_roms_sgrid(roms_sgrid):
+    return load_grid(roms_sgrid)
+
+
+def test_center_lon(sgrid_roms_sgrid):
+    center_lon = sgrid_roms_sgrid.center_lon
+    assert center_lon.shape == (4, 4)
+
+
+def test_center_lat(sgrid_roms_sgrid):
+    center_lat = sgrid_roms_sgrid.center_lat
+    assert center_lat.shape == (4, 4)
+
+
+def test_variables(sgrid_roms_sgrid):
+    dataset_vars = sgrid_roms_sgrid.variables
+    expected_vars = [u's_rho',
+                     u's_w',
+                     u'time',
+                     u'xi_rho',
+                     u'eta_rho',
+                     u'xi_psi',
+                     u'eta_psi',
+                     u'xi_u',
+                     u'eta_u',
+                     u'xi_v',
+                     u'eta_v',
+                     u'grid',
+                     u'u',
+                     u'v',
+                     u'fake_u',
+                     u'lon_rho',
+                     u'lat_rho',
+                     u'lon_psi',
+                     u'lat_psi',
+                     u'lat_u',
+                     u'lon_u',
+                     u'lat_v',
+                     u'lon_v',
+                     u'salt',
+                     u'zeta']
+    assert len(dataset_vars) == len(expected_vars)
+    assert dataset_vars == expected_vars
+
+
+def test_grid_variables(sgrid_roms_sgrid):
+    dataset_grid_variables = sgrid_roms_sgrid.grid_variables
+    expected_grid_variables = [u'u', u'v', u'fake_u', u'salt']
+    assert len(dataset_grid_variables) == len(expected_grid_variables)
+    assert set(dataset_grid_variables) == set(expected_grid_variables)
+
+
+def test_non_grid_variables(sgrid_roms_sgrid):
+    dataset_non_grid_variables = sgrid_roms_sgrid.non_grid_variables
+    expected_non_grid_variables = [u's_rho',
+                                   u's_w',
+                                   u'time',
+                                   u'xi_rho',
+                                   u'eta_rho',
+                                   u'xi_psi',
+                                   u'eta_psi',
+                                   u'xi_u',
+                                   u'eta_u',
+                                   u'xi_v',
+                                   u'eta_v',
+                                   u'grid',
+                                   u'lon_rho',
+                                   u'lat_rho',
+                                   u'lon_psi',
+                                   u'lat_psi',
+                                   u'lat_u',
+                                   u'lon_u',
+                                   u'lat_v',
+                                   u'lon_v',
+                                   u'zeta']
+    assert len(dataset_non_grid_variables) == len(expected_non_grid_variables)
+    assert set(dataset_non_grid_variables) == set(expected_non_grid_variables)
+
+
+def test_variable_slicing(sgrid_roms_sgrid):
+    u_center_slices = sgrid_roms_sgrid.u.center_slicing
+    v_center_slices = sgrid_roms_sgrid.v.center_slicing
+    u_center_expected = (np.s_[:], np.s_[:], np.s_[1:-1], np.s_[:])
+    v_center_expected = (np.s_[:], np.s_[:], np.s_[:], np.s_[1:-1])
+    assert u_center_slices == u_center_expected
+    assert v_center_slices == v_center_expected
+
+
+def test_grid_variable_average_axes(sgrid_roms_sgrid):
+    uc_axis = sgrid_roms_sgrid.u.center_axis
+    uc_axis_expected = 1
+    un_axis = sgrid_roms_sgrid.u.node_axis
+    un_axis_expected = 0
+    lon_rho_c_axis = sgrid_roms_sgrid.lon_rho.center_axis
+    lon_rho_n_axis = sgrid_roms_sgrid.lon_rho.node_axis
+    assert uc_axis == uc_axis_expected
+    assert un_axis == un_axis_expected
+    assert lon_rho_c_axis is None
+    assert lon_rho_n_axis is None
+
+
+def test_optional_grid_attrs(sgrid_roms_sgrid):
+    face_coordinates = sgrid_roms_sgrid.face_coordinates
+    node_coordinates = sgrid_roms_sgrid.node_coordinates
+    edge1_coordinates = sgrid_roms_sgrid.edge1_coordinates
+    edge2_coordinates = sgrid_roms_sgrid.edge2_coordinates
+    fc_expected = ('lon_rho', 'lat_rho')
+    nc_expected = ('lon_psi', 'lat_psi')
+    e1c_expected = ('lon_u', 'lat_u')
+    e2c_expected = ('lon_v', 'lat_v')
+    assert face_coordinates == fc_expected
+    assert node_coordinates == nc_expected
+    assert edge1_coordinates == e1c_expected
+    assert edge2_coordinates == e2c_expected
+
+
+def test_round_trip(sgrid_roms_sgrid, tmpdir):
+    """
+    TODO: add more "round-trip" tests.
+
+    """
+    fname = tmpdir.mkdir('files').join('deltares_roundtrip.nc')
+    sgrid_roms_sgrid.save_as_netcdf(fname)
+    result = load_grid(fname)
+    assert isinstance(result, SGrid)

--- a/pysgrid/tests/test_sgrid_variable_deltares.py
+++ b/pysgrid/tests/test_sgrid_variable_deltares.py
@@ -1,0 +1,50 @@
+"""
+Test SGrid Variables Deltares.
+
+Created on Apr 15, 2015
+
+@author: ayan
+
+"""
+
+from __future__ import (absolute_import, division, print_function)
+
+import pytest
+
+from ..sgrid import SGrid
+from ..utils import GridPadding
+from ..variables import SGridVariable
+from .write_nc_test_files import deltares_sgrid
+
+
+@pytest.fixture
+def sgrid_vars_deltares(deltares_sgrid):
+    face_padding = [GridPadding(mesh_topology_var=u'grid',
+                                face_dim=u'MMAXZ',
+                                node_dim=u'MMAX',
+                                padding=u'low'),
+                    GridPadding(mesh_topology_var=u'grid',
+                                face_dim=u'NMAXZ',
+                                node_dim=u'NMAX',
+                                padding=u'low')]
+    node_dimensions = 'MMAX NMAX'
+    return dict(sgrid=SGrid(face_padding=face_padding,
+                            node_dimensions=node_dimensions),
+                test_var_1=deltares_sgrid.variables['FAKE_W'],
+                test_var_2=deltares_sgrid.variables['FAKE_U1'])
+
+
+def test_face_location_inference_deltares(sgrid_vars_deltares):
+    sg_var = SGridVariable.create_variable(sgrid_vars_deltares['test_var_1'],
+                                           sgrid_vars_deltares['sgrid'])
+    sg_var_location = sg_var.location
+    expected_location = 'face'
+    assert sg_var_location == expected_location
+
+
+def test_edge_location_inference_deltares(sgrid_vars_deltares):
+    sg_var = SGridVariable.create_variable(sgrid_vars_deltares['test_var_2'],
+                                           sgrid_vars_deltares['sgrid'])
+    sg_var_location = sg_var.location
+    expected_location = 'edge2'
+    assert sg_var_location == expected_location

--- a/pysgrid/tests/test_sgrid_variable_roms.py
+++ b/pysgrid/tests/test_sgrid_variable_roms.py
@@ -1,8 +1,11 @@
-'''
+"""
+Test SGrid Variable ROMS.
+
 Created on Apr 15, 2015
 
 @author: ayan
-'''
+
+"""
 
 from __future__ import (absolute_import, division, print_function)
 
@@ -13,10 +16,9 @@ import numpy as np
 from ..sgrid import SGrid
 from ..utils import GridPadding
 from ..variables import SGridVariable
-from .write_nc_test_files import deltares_sgrid, roms_sgrid, wrf_sgrid_2d
+from .write_nc_test_files import roms_sgrid
 
 
-# TestSGridVariableROMS.
 @pytest.fixture
 def sgrid_variable_roms(roms_sgrid):
     face_padding = [GridPadding(mesh_topology_var=u'grid',
@@ -155,73 +157,3 @@ def test_vector_directions(sgrid_variable_roms):
     zeta_axis = zeta_var.vector_axis
     assert u_vector_axis == expected_u_axis
     assert zeta_axis is None
-
-
-# TestSGridVariablesWRF.
-@pytest.fixture
-def sgrid_var_wrf(wrf_sgrid_2d):
-    face_padding = [GridPadding(mesh_topology_var=u'grid',
-                                face_dim=u'west_east',
-                                node_dim=u'west_east_stag',
-                                padding=u'none'),
-                    GridPadding(mesh_topology_var=u'grid',
-                                face_dim=u'south_north',
-                                node_dim=u'south_north_stag',
-                                padding=u'none')]
-    node_dimensions = 'west_east_stag south_north_stag'
-    return dict(sgrid=SGrid(face_padding=face_padding,
-                            node_dimensions=node_dimensions),
-                test_var_1=wrf_sgrid_2d.variables['SNOW'],
-                test_var_2=wrf_sgrid_2d.variables['FAKE_U'])
-
-
-def test_face_location_inference1(sgrid_var_wrf):
-    sg_var = SGridVariable.create_variable(sgrid_var_wrf['test_var_1'],
-                                           sgrid_var_wrf['sgrid'])
-    sg_var_location = sg_var.location
-    expected_location = 'face'
-    assert sg_var_location == expected_location
-
-
-def test_edge_location_inference2(sgrid_var_wrf):
-    sg_var = SGridVariable.create_variable(sgrid_var_wrf['test_var_2'],
-                                           sgrid_var_wrf['sgrid'])
-    sg_var_location = sg_var.location
-    expected_location = 'edge1'
-    assert sg_var_location == expected_location
-
-
-# TestSGridVariablesDeltares
-
-
-@pytest.fixture
-def sgrid_vars_deltares(deltares_sgrid):
-    face_padding = [GridPadding(mesh_topology_var=u'grid',
-                                face_dim=u'MMAXZ',
-                                node_dim=u'MMAX',
-                                padding=u'low'),
-                    GridPadding(mesh_topology_var=u'grid',
-                                face_dim=u'NMAXZ',
-                                node_dim=u'NMAX',
-                                padding=u'low')]
-    node_dimensions = 'MMAX NMAX'
-    return dict(sgrid=SGrid(face_padding=face_padding,
-                            node_dimensions=node_dimensions),
-                test_var_1=deltares_sgrid.variables['FAKE_W'],
-                test_var_2=deltares_sgrid.variables['FAKE_U1'])
-
-
-def test_face_location_inference_deltares(sgrid_vars_deltares):
-    sg_var = SGridVariable.create_variable(sgrid_vars_deltares['test_var_1'],
-                                           sgrid_vars_deltares['sgrid'])
-    sg_var_location = sg_var.location
-    expected_location = 'face'
-    assert sg_var_location == expected_location
-
-
-def test_edge_location_inference_deltares(sgrid_vars_deltares):
-    sg_var = SGridVariable.create_variable(sgrid_vars_deltares['test_var_2'],
-                                           sgrid_vars_deltares['sgrid'])
-    sg_var_location = sg_var.location
-    expected_location = 'edge2'
-    assert sg_var_location == expected_location

--- a/pysgrid/tests/test_sgrid_variable_wrf.py
+++ b/pysgrid/tests/test_sgrid_variable_wrf.py
@@ -1,0 +1,51 @@
+"""
+Test SGrid Variables WRF.
+
+Created on Apr 15, 2015
+
+@author: ayan
+
+"""
+
+
+from __future__ import (absolute_import, division, print_function)
+
+import pytest
+
+from ..sgrid import SGrid
+from ..utils import GridPadding
+from ..variables import SGridVariable
+from .write_nc_test_files import wrf_sgrid_2d
+
+
+@pytest.fixture
+def sgrid_var_wrf(wrf_sgrid_2d):
+    face_padding = [GridPadding(mesh_topology_var=u'grid',
+                                face_dim=u'west_east',
+                                node_dim=u'west_east_stag',
+                                padding=u'none'),
+                    GridPadding(mesh_topology_var=u'grid',
+                                face_dim=u'south_north',
+                                node_dim=u'south_north_stag',
+                                padding=u'none')]
+    node_dimensions = 'west_east_stag south_north_stag'
+    return dict(sgrid=SGrid(face_padding=face_padding,
+                            node_dimensions=node_dimensions),
+                test_var_1=wrf_sgrid_2d.variables['SNOW'],
+                test_var_2=wrf_sgrid_2d.variables['FAKE_U'])
+
+
+def test_face_location_inference1(sgrid_var_wrf):
+    sg_var = SGridVariable.create_variable(sgrid_var_wrf['test_var_1'],
+                                           sgrid_var_wrf['sgrid'])
+    sg_var_location = sg_var.location
+    expected_location = 'face'
+    assert sg_var_location == expected_location
+
+
+def test_edge_location_inference2(sgrid_var_wrf):
+    sg_var = SGridVariable.create_variable(sgrid_var_wrf['test_var_2'],
+                                           sgrid_var_wrf['sgrid'])
+    sg_var_location = sg_var.location
+    expected_location = 'edge1'
+    assert sg_var_location == expected_location

--- a/pysgrid/tests/test_sgrid_variable_wrf.py
+++ b/pysgrid/tests/test_sgrid_variable_wrf.py
@@ -15,11 +15,11 @@ import pytest
 from ..sgrid import SGrid
 from ..utils import GridPadding
 from ..variables import SGridVariable
-from .write_nc_test_files import wrf_sgrid_2d
+from .write_nc_test_files import wrf_sgrid
 
 
 @pytest.fixture
-def sgrid_var_wrf(wrf_sgrid_2d):
+def sgrid_var_wrf(wrf_sgrid):
     face_padding = [GridPadding(mesh_topology_var=u'grid',
                                 face_dim=u'west_east',
                                 node_dim=u'west_east_stag',
@@ -31,8 +31,8 @@ def sgrid_var_wrf(wrf_sgrid_2d):
     node_dimensions = 'west_east_stag south_north_stag'
     return dict(sgrid=SGrid(face_padding=face_padding,
                             node_dimensions=node_dimensions),
-                test_var_1=wrf_sgrid_2d.variables['SNOW'],
-                test_var_2=wrf_sgrid_2d.variables['FAKE_U'])
+                test_var_1=wrf_sgrid.variables['SNOW'],
+                test_var_2=wrf_sgrid.variables['FAKE_U'])
 
 
 def test_face_location_inference1(sgrid_var_wrf):

--- a/pysgrid/tests/test_sgrid_wrf.py
+++ b/pysgrid/tests/test_sgrid_wrf.py
@@ -1,0 +1,95 @@
+"""
+Created on Apr 7, 2015
+
+@author: ayan
+
+"""
+
+from __future__ import (absolute_import, division, print_function)
+
+import pytest
+import numpy as np
+
+from ..sgrid import SGrid, load_grid
+
+from .write_nc_test_files import wrf_sgrid_2d
+
+
+"""
+Test SGrid WRF Dataset.
+
+"""
+
+
+@pytest.fixture
+def sgrid(wrf_sgrid_2d):
+    return load_grid(wrf_sgrid_2d)
+
+
+def test_topology_dimension(sgrid):
+    topology_dim = sgrid.topology_dimension
+    expected_dim = 2
+    assert topology_dim == expected_dim
+
+
+def test_variable_slicing_wrf(sgrid):
+    u_slice = sgrid.U.center_slicing
+    u_expected = (np.s_[:], np.s_[:], np.s_[:], np.s_[:])
+    v_slice = sgrid.V.center_slicing
+    v_expected = (np.s_[:], np.s_[:], np.s_[:], np.s_[:])
+    assert u_slice == u_expected
+    assert v_slice == v_expected
+
+
+def test_variable_average_axes(sgrid):
+    u_avg_axis = sgrid.U.center_axis
+    u_axis_expected = 1
+    v_avg_axis = sgrid.V.center_axis
+    v_axis_expected = 0
+    assert u_avg_axis == u_axis_expected
+    assert v_avg_axis == v_axis_expected
+
+
+"""
+Test SGrid Save No-Node Coordinates.
+
+This scenario will typically occur with WRF datasets.
+
+"""
+
+
+def test_roundtrip(wrf_sgrid_2d, tmpdir):
+    """
+    TODO: add more "round-trip" tests.
+
+    """
+    fname = tmpdir.mkdir('files').join('wrf_roundtrip.nc')
+    sg_obj = load_grid(wrf_sgrid_2d)
+    sg_obj.save_as_netcdf(fname)
+
+
+@pytest.fixture
+def sgrid_sgrid_2d(wrf_sgrid_2d):
+    return load_grid(wrf_sgrid_2d)
+
+
+def test_sgrid(sgrid_sgrid_2d):
+    assert isinstance(sgrid_sgrid_2d, SGrid)
+
+
+def test_nodes(sgrid_sgrid_2d):
+    node_lon = sgrid_sgrid_2d.node_lon
+    node_lat = sgrid_sgrid_2d.node_lat
+    assert node_lon is None
+    assert node_lat is None
+
+
+def test_node_coordinates(sgrid_sgrid_2d):
+    node_coordinates = sgrid_sgrid_2d.node_coordinates
+    assert node_coordinates is None
+
+
+def test_node_dimensions(sgrid_sgrid_2d):
+    node_dims = sgrid_sgrid_2d.node_dimensions
+    expected = 'west_east_stag south_north_stag'
+    assert node_dims == expected

--- a/pysgrid/tests/test_sgrid_wrf.py
+++ b/pysgrid/tests/test_sgrid_wrf.py
@@ -50,46 +50,34 @@ def test_variable_average_axes(sgrid):
     assert v_avg_axis == v_axis_expected
 
 
-"""
-Test SGrid Save No-Node Coordinates.
-
-This scenario will typically occur with WRF datasets.
-
-"""
-
-
 def test_roundtrip(wrf_sgrid_2d, tmpdir):
     """
     TODO: add more "round-trip" tests.
 
+    Test SGrid Save No-Node Coordinates.
     """
     fname = tmpdir.mkdir('files').join('wrf_roundtrip.nc')
     sg_obj = load_grid(wrf_sgrid_2d)
     sg_obj.save_as_netcdf(fname)
 
 
-@pytest.fixture
-def sgrid_sgrid_2d(wrf_sgrid_2d):
-    return load_grid(wrf_sgrid_2d)
+def test_sgrid(sgrid):
+    assert isinstance(sgrid, SGrid)
 
 
-def test_sgrid(sgrid_sgrid_2d):
-    assert isinstance(sgrid_sgrid_2d, SGrid)
-
-
-def test_nodes(sgrid_sgrid_2d):
-    node_lon = sgrid_sgrid_2d.node_lon
-    node_lat = sgrid_sgrid_2d.node_lat
+def test_nodes(sgrid):
+    node_lon = sgrid.node_lon
+    node_lat = sgrid.node_lat
     assert node_lon is None
     assert node_lat is None
 
 
-def test_node_coordinates(sgrid_sgrid_2d):
-    node_coordinates = sgrid_sgrid_2d.node_coordinates
+def test_node_coordinates(sgrid):
+    node_coordinates = sgrid.node_coordinates
     assert node_coordinates is None
 
 
-def test_node_dimensions(sgrid_sgrid_2d):
-    node_dims = sgrid_sgrid_2d.node_dimensions
+def test_node_dimensions(sgrid):
+    node_dims = sgrid.node_dimensions
     expected = 'west_east_stag south_north_stag'
     assert node_dims == expected

--- a/pysgrid/tests/test_sgrid_wrf.py
+++ b/pysgrid/tests/test_sgrid_wrf.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from ..sgrid import SGrid, load_grid
 
-from .write_nc_test_files import wrf_sgrid_2d
+from .write_nc_test_files import wrf_sgrid
 
 
 """
@@ -22,8 +22,8 @@ Test SGrid WRF Dataset.
 
 
 @pytest.fixture
-def sgrid(wrf_sgrid_2d):
-    return load_grid(wrf_sgrid_2d)
+def sgrid(wrf_sgrid):
+    return load_grid(wrf_sgrid)
 
 
 def test_topology_dimension(sgrid):
@@ -50,14 +50,14 @@ def test_variable_average_axes(sgrid):
     assert v_avg_axis == v_axis_expected
 
 
-def test_roundtrip(wrf_sgrid_2d, tmpdir):
+def test_roundtrip(wrf_sgrid, tmpdir):
     """
     TODO: add more "round-trip" tests.
 
     Test SGrid Save No-Node Coordinates.
     """
     fname = tmpdir.mkdir('files').join('wrf_roundtrip.nc')
-    sg_obj = load_grid(wrf_sgrid_2d)
+    sg_obj = load_grid(wrf_sgrid)
     sg_obj.save_as_netcdf(fname)
 
 

--- a/pysgrid/tests/test_utils.py
+++ b/pysgrid/tests/test_utils.py
@@ -1,12 +1,13 @@
-'''
+"""
 Created on Mar 23, 2015
 
 @author: ayan
-'''
+
+"""
 
 from __future__ import (absolute_import, division, print_function)
 
-import unittest
+import pytest
 
 import numpy as np
 
@@ -14,93 +15,97 @@ from ..utils import (calculate_bearing, calculate_angle_from_true_east,
                      check_element_equal, does_intersection_exist, pair_arrays)
 
 
-class TestDoesIntersectionExist(unittest.TestCase):
-
-    def setUp(self):
-        self.tuple_a = (718, 903, 1029, 1701)
-        self.tuple_b = (718, 828)
-        self.tuple_c = (15, 20)
-
-    def test_intersect_exists(self):
-        result = does_intersection_exist(self.tuple_a, self.tuple_b)
-        self.assertTrue(result)
-
-    def test_intersect_does_not_exist(self):
-        result = does_intersection_exist(self.tuple_a, self.tuple_c)
-        self.assertFalse(result)
+@pytest.fixture
+def intersection_data():
+    a = (718, 903, 1029, 1701)
+    b = (718, 828)
+    c = (15, 20)
+    return a, b, c
 
 
-class TestPairArrays(unittest.TestCase):
-
-    def setUp(self):
-        self.a1 = (1, 2)
-        self.a2 = (3, 4)
-        self.a3 = (5, 6)
-        self.b1 = (10, 20)
-        self.b2 = (30, 40)
-        self.b3 = (50, 60)
-        self.a = np.array([self.a1, self.a2, self.a3])
-        self.b = np.array([self.b1, self.b2, self.b3])
-
-    def test_pair_arrays(self):
-        result = pair_arrays(self.a, self.b)
-        x = [[(1, 10), (2, 20)],
-             [(3, 30), (4, 40)],
-             [(5, 50), (6, 60)]]
-        expected = np.array(x)
-        np.testing.assert_almost_equal(result, expected, decimal=3)
+def test_intersect_exists():
+    a, b, c = intersection_data()
+    result = does_intersection_exist(a, b)
+    assert result
 
 
-class TestCheckElementEqual(unittest.TestCase):
-
-    def setUp(self):
-        self.a = [7, 7, 7, 7]
-        self.b = [7, 8, 9, 10]
-
-    def test_list_with_identical_elements(self):
-        result = check_element_equal(self.a)
-        self.assertTrue(result)
-
-    def test_list_with_different_elements(self):
-        result = check_element_equal(self.b)
-        self.assertFalse(result)
+def test_intersect_does_not_exist():
+    a, b, c = intersection_data()
+    result = does_intersection_exist(a, c)
+    assert result is False
 
 
-class TestCalculateBearing(unittest.TestCase):
-
-    def setUp(self):
-        self.points = np.array([(-93.51105439, 11.88846735),
-                                (-93.46607342, 11.90917952)])
-        self.point_1 = self.points[:-1, :]
-        self.point_2 = self.points[1:, :]
-
-    def test_bearing_calculation(self):
-        result = calculate_bearing(self.point_1, self.point_2)
-        expected = 64.7947
-        np.testing.assert_almost_equal(result, expected, decimal=3)
+def test_pair_arrays():
+    a1, a2, a3 = (1, 2), (3, 4), (5, 6)
+    b1, b2, b3 = (10, 20), (30, 40), (50, 60)
+    a = np.array([a1, a2, a3])
+    b = np.array([b1, b2, b3])
+    result = pair_arrays(a, b)
+    expected = np.array([[(1, 10), (2, 20)],
+                         [(3, 30), (4, 40)],
+                         [(5, 50), (6, 60)]])
+    np.testing.assert_almost_equal(result, expected, decimal=3)
 
 
-class TestCalculateAngleFromTrueEast(unittest.TestCase):
+@pytest.fixture
+def check_element():
+    """
+    FIXME: These tests only check for a True return and not for correctness.
 
-    def setUp(self):
-        self.vertical_1 = np.array([[-122.41, 37.78], [-122.33, 37.84], [-122.22, 37.95]])  # noqa
-        self.vertical_2 = np.array([[-90.07, 29.95], [-89.97, 29.84], [-89.91, 29.76]])  # noqa
-        self.vertical_3 = np.array([[-89.40, 43.07], [-89.49, 42.93], [-89.35, 42.84]])  # noqa
-        self.vertical_4 = np.array([[-122.41, 37.78], [-122.53, 37.84], [-122.67, 37.95]])  # noqa
-        self.centers = np.array((self.vertical_1,
-                                 self.vertical_2,
-                                 self.vertical_3,
-                                 self.vertical_4))
+    """
+    a = [7, 7, 7, 7]
+    b = [7, 8, 9, 10]
+    return a, b
 
-    def test_angle_from_true_east_calculation(self):
-        bearing_start_points = self.centers[:, :-1, :]
-        bearing_end_points = self.centers[:, 1:, :]
-        angle_from_true_east = calculate_angle_from_true_east(bearing_start_points, bearing_end_points)  # noqa
-        expected_values = np.array([[0.7598, 0.9033, 0.9033],
-                                    [-0.903, -0.994, -0.994],
-                                    [-2.011, -0.719, -0.719],
-                                    [-3.706, -3.926, -3.926]
-                                    ])
-        expected_shape = (4, 3)
-        np.testing.assert_almost_equal(angle_from_true_east, expected_values, decimal=3)  # noqa
-        self.assertEqual(angle_from_true_east.shape, expected_shape)
+
+def test_list_with_identical_elements():
+    a, b = check_element()
+    result = check_element_equal(a)
+    assert result
+
+
+def test_list_with_different_elements():
+    a, b = check_element()
+    result = check_element_equal(b)
+    assert result is False
+
+
+def test_bearing_calculation():
+    points = np.array([(-93.51105439, 11.88846735),
+                       (-93.46607342, 11.90917952)])
+    point_1 = points[:-1, :]
+    point_2 = points[1:, :]
+    result = calculate_bearing(point_1, point_2)
+    expected = 64.7947
+    np.testing.assert_almost_equal(result, expected, decimal=3)
+
+
+def test_angle_from_true_east_calculation():
+    vertical_1 = np.array([[-122.41, 37.78],
+                           [-122.33, 37.84],
+                           [-122.22, 37.95]])
+    vertical_2 = np.array([[-90.07, 29.95],
+                           [-89.97, 29.84],
+                           [-89.91, 29.76]])
+    vertical_3 = np.array([[-89.40, 43.07],
+                           [-89.49, 42.93],
+                           [-89.35, 42.84]])
+    vertical_4 = np.array([[-122.41, 37.78],
+                           [-122.53, 37.84],
+                           [-122.67, 37.95]])
+    centers = np.array((vertical_1,
+                        vertical_2,
+                        vertical_3,
+                        vertical_4))
+
+    bearing_start_points = centers[:, :-1, :]
+    bearing_end_points = centers[:, 1:, :]
+    angle_from_true_east = calculate_angle_from_true_east(bearing_start_points, bearing_end_points)  # noqa
+    expected_values = np.array([[0.7598, 0.9033, 0.9033],
+                                [-0.903, -0.994, -0.994],
+                                [-2.011, -0.719, -0.719],
+                                [-3.706, -3.926, -3.926]])
+    expected_shape = (4, 3)
+    np.testing.assert_almost_equal(angle_from_true_east,
+                                   expected_values, decimal=3)
+    assert angle_from_true_east.shape == expected_shape

--- a/pysgrid/tests/write_nc_test_files.py
+++ b/pysgrid/tests/write_nc_test_files.py
@@ -1,25 +1,28 @@
-'''
+"""
 Created on Apr 7, 2015
 
 @author: ayan
-'''
+
+"""
 
 from __future__ import (absolute_import, division, print_function)
 
 import os
+import tempfile
 
 import pytest
 import numpy as np
 from netCDF4 import Dataset
 
-from pysgrid.lookup import (LON_GRID_CELL_CENTER_LONG_NAME,
-                            LAT_GRID_CELL_CENTER_LONG_NAME,
-                            LON_GRID_CELL_NODE_LONG_NAME,
-                            LAT_GRID_CELL_NODE_LONG_NAME)
+from ..lookup import (LON_GRID_CELL_CENTER_LONG_NAME,
+                      LAT_GRID_CELL_CENTER_LONG_NAME,
+                      LON_GRID_CELL_NODE_LONG_NAME,
+                      LAT_GRID_CELL_NODE_LONG_NAME)
 
 
 @pytest.yield_fixture
-def deltares_sgrid_no_optional_attr(fname='tmp_sgrid_deltares_no_opt_attr.nc'):
+def deltares_sgrid_no_optional_attr():
+    fname = tempfile.mktemp(suffix='.nc')
     nc = Dataset(fname, 'w')
     # Define dimensions.
     nc.createDimension('MMAXZ', 4)
@@ -77,13 +80,14 @@ def deltares_sgrid_no_optional_attr(fname='tmp_sgrid_deltares_no_opt_attr.nc'):
 
 
 @pytest.yield_fixture
-def deltares_sgrid(fname='tmp_sgrid_deltares.nc'):
+def deltares_sgrid():
     """
     Create a netCDF file that is structurally similar to
     deltares output. Dimension and variable names may differ
     from an actual file.
 
     """
+    fname = tempfile.mktemp(suffix='.nc')
     nc = Dataset(fname, 'w')
     # Define dimensions.
     nc.createDimension('MMAXZ', 4)
@@ -136,7 +140,7 @@ def deltares_sgrid(fname='tmp_sgrid_deltares.nc'):
     w.grid = 'grid'
     w.location = 'face'
     fake_w.grid = 'grid'
-    # create variable data
+    # Create variable data.
     xcor[:] = np.random.random((4, 4))
     ycor[:] = np.random.random((4, 4))
     xz[:] = np.random.random((4, 4))
@@ -158,13 +162,14 @@ def deltares_sgrid(fname='tmp_sgrid_deltares.nc'):
 
 
 @pytest.yield_fixture
-def roms_sgrid(fname='tmp_sgrid_roms.nc'):
+def roms_sgrid():
     """
     Create a netCDF file that is structurally similar to
     ROMS output. Dimension and variable names may differ
     from an actual file.
 
     """
+    fname = tempfile.mktemp(suffix='.nc')
     nc = Dataset(fname, 'w')
     # Set dimensions.
     nc.createDimension('s_rho', 2)
@@ -267,7 +272,8 @@ def roms_sgrid(fname='tmp_sgrid_roms.nc'):
 
 
 @pytest.yield_fixture
-def wrf_sgrid_2d(fname='tmp_sgrid_wrf_2.nc'):
+def wrf_sgrid():
+    fname = tempfile.mktemp(suffix='.nc')
     nc = Dataset(fname, 'w')
     nc.createDimension('Time', 2)
     nc.createDimension('DateStrLen', 3)
@@ -330,74 +336,14 @@ def wrf_sgrid_2d(fname='tmp_sgrid_wrf_2.nc'):
 
 
 @pytest.yield_fixture
-def wrf_sgrid(fname='tmp_sgrid_wrf.nc'):
-    """
-    Write an SGrid file using 3D conventions.
-
-    """
-    nc = Dataset(fname, 'w')
-    # Create dimensions.
-    nc.createDimension('Time', 2)
-    nc.createDimension('DateStrLen', 3)
-    nc.createDimension('west_east', 4)
-    nc.createDimension('south_north', 5)
-    nc.createDimension('west_east_stag', 5)
-    nc.createDimension('bottom_top', 3)
-    nc.createDimension('south_north_stag', 6)
-    nc.createDimension('bottom_top_stag', 4)
-    # Create variables.
-    times = nc.createVariable('Times', np.dtype(str), ('Time', 'DateStrLen'))  # noqa
-    xtimes = nc.createVariable('XTIME', 'f8', ('Time',))
-    xtimes.standard_name = 'time'
-    us = nc.createVariable('U', 'f4', ('Time', 'bottom_top', 'south_north', 'west_east_stag'))  # noqa
-    us.grid = 'grid'
-    us.location = 'face1'
-    vs = nc.createVariable('V', 'f4', ('Time', 'bottom_top', 'south_north_stag', 'west_east'))  # noqa
-    vs.grid = 'grid'
-    vs.location = 'face2'
-    ws = nc.createVariable('W', 'f4', ('Time', 'bottom_top_stag', 'south_north', 'west_east'))  # noqa
-    ws.grid = 'grid'
-    ws.location = 'face3'
-    temps = nc.createVariable('T', 'f4', ('Time', 'bottom_top', 'south_north', 'west_east'))  # noqa
-    temps.grid = 'grid'
-    temps.location = 'volume'
-    xlats = nc.createVariable('XLAT', 'f4', ('Time', 'south_north', 'west_east'))  # noqa
-    xlongs = nc.createVariable('XLONG', 'f4', ('Time', 'south_north', 'west_east'))  # noqa
-    znus = nc.createVariable('ZNU', 'f4', ('Time', 'bottom_top'))
-    znws = nc.createVariable('ZNW', 'f4', ('Time', 'bottom_top_stag'))
-    grid = nc.createVariable('grid', 'i2')
-    grid.cf_role = 'grid_topology'
-    grid.topology_dimension = 3
-    grid.node_dimensions = 'west_east_stag south_north_stag bottom_top_stag'  # noqa
-    grid.volume_dimensions = ('west_east: west_east_stag (padding: none) '
-                                'south_north: south_north_stag (padding: none) '  # noqa
-                                'bottom_top: bottom_top_stag (padding: none)')  # noqa
-    grid.volume_coordinates = 'XLONG XLAT ZNU'
-    # create fake data
-    times[:] = np.random.random(size=(2, 3)).astype(str)
-    xtimes[:] = np.random.random(size=(2,))
-    us[:, :, :, :] = np.random.random(size=(2, 3, 5, 5))
-    vs[:, :, :, :] = np.random.random(size=(2, 3, 6, 4))
-    ws[:, :, :, :] = np.random.random(size=(2, 4, 5, 4))
-    temps[:, :, :, :] = np.random.random(size=(2, 3, 5, 4))
-    xlats[:, :, :] = np.random.random(size=(2, 5, 4))
-    xlongs[:, :, :] = np.random.random(size=(2, 5, 4))
-    znus[:, :] = np.random.random(size=(2, 3))
-    znws[:, :] = np.random.random(size=(2, 4))
-    nc.sync()
-    yield nc
-    nc.close()
-    os.remove(fname)
-
-
-@pytest.yield_fixture
-def non_compliant_sgrid(fname='tmp_noncompliant_sgrid.nc'):
+def non_compliant_sgrid():
     """
     Create a netCDF file that is structurally similar to
     ROMS output. Dimension and variable names may differ
     from an actual file.
 
     """
+    fname = tempfile.mktemp(suffix='.nc')
     nc = Dataset(fname, 'w')
     nc.createDimension('z_center', 2)
     nc.createDimension('z_node', 3)
@@ -410,7 +356,7 @@ def non_compliant_sgrid(fname='tmp_noncompliant_sgrid.nc'):
     nc.createDimension('y_u', 4)
     nc.createDimension('x_v', 4)
     nc.createDimension('y_v', 3)
-    # create coordinate variables
+    # Create coordinate variables.
     z_centers = nc.createVariable('z_center', 'i4', ('z_center',))
     nc.createVariable('z_node', 'i4', ('z_node',))
     times = nc.createVariable('time', 'f8', ('time',))
@@ -422,7 +368,7 @@ def non_compliant_sgrid(fname='tmp_noncompliant_sgrid.nc'):
     y_us = nc.createVariable('y_u', 'f4', ('y_u',))
     x_vs = nc.createVariable('x_v', 'f4', ('x_v',))
     y_vs = nc.createVariable('y_v', 'f4', ('y_v',))
-    # create other variables
+    # Create other variables.
     grid = nc.createVariable('grid', 'i2')
     u = nc.createVariable('u', 'f4', ('time', 'z_center', 'y_u', 'x_u'))
     v = nc.createVariable('v', 'f4', ('time', 'z_center', 'y_v', 'x_v'))
@@ -434,7 +380,7 @@ def non_compliant_sgrid(fname='tmp_noncompliant_sgrid.nc'):
     lon_u = nc.createVariable('lon_u', 'f4', ('y_u', 'x_u'))
     lat_v = nc.createVariable('lat_v', 'f4', ('y_v', 'x_v'))
     lon_v = nc.createVariable('lon_v', 'f4', ('y_v', 'x_v'))
-    # create variable attributes
+    # Create variable attributes.
     lon_centers.long_name = LON_GRID_CELL_CENTER_LONG_NAME[0]
     lat_centers.long_name = LAT_GRID_CELL_CENTER_LONG_NAME[0]
     lon_nodes.long_name = LON_GRID_CELL_NODE_LONG_NAME[0]
@@ -449,7 +395,7 @@ def non_compliant_sgrid(fname='tmp_noncompliant_sgrid.nc'):
     grid.edge1_coordinates = 'lon_u lat_u'
     grid.edge2_coordinates = 'lon_v lat_v'
     grid.vertical_dimensions = 'z_center: z_node (padding: none)'
-    # create coordinate data
+    # Create coordinate data.
     z_centers[:] = np.random.random(size=(2,))
     times[:] = np.random.random(size=(2,))
     lon_centers[:, :] = np.random.random(size=(4, 4))


### PR DESCRIPTION
Seems like a lot of changes but in this PR I am mostly moving things around and adapting the tests to use `pytest` everywhere.

- split big test files into smaller and more manage ones based on the scope of the test
- replace clunky `unittest` classes for simpler `pytest` functions
- safer creation of temporary test files
- remove some redundant code and tests 
- added round-trip (save/read) tests